### PR TITLE
Fix waypoint integration tests to handle MAVLink home waypoint

### DIFF
--- a/projects/integration-tests/conftest.py
+++ b/projects/integration-tests/conftest.py
@@ -111,7 +111,7 @@ def sample_waypoint():
     and param1-4 are omitted to test default behavior.
 
     Returns:
-        dict: Waypoint dictionary with minimal required fields
+        dict: Waypoint dictionary with valid required fields
     """
     return {
         "id": 1,
@@ -130,7 +130,7 @@ def sample_waypoints():
     work without specifying command or param fields.
 
     Returns:
-        list: List of waypoint dictionaries with minimal fields
+        list: List of waypoint dictionaries with valid required fields
     """
     return [
         {

--- a/projects/integration-tests/conftest.py
+++ b/projects/integration-tests/conftest.py
@@ -111,10 +111,16 @@ def sample_waypoint():
         dict: Waypoint dictionary with valid test data
     """
     return {
-        "name": "TestWP1",
+        "id": 0,
+        "name": "Test Waypoint",
         "latitude": -35.363261,
         "longitude": 149.165230,
         "altitude": 50.0,
+        "command": "WAYPOINT",
+        "param1": 0,
+        "param2": 0,
+        "param3": 0,
+        "param4": 0
     }
 
 

--- a/projects/integration-tests/conftest.py
+++ b/projects/integration-tests/conftest.py
@@ -107,20 +107,18 @@ def reset_drone_state(api_client):
 def sample_waypoint():
     """Provide a sample waypoint for testing.
 
+    Uses minimal required fields. Optional fields like altitude, command,
+    and param1-4 are omitted to test default behavior.
+
     Returns:
-        dict: Waypoint dictionary with valid test data
+        dict: Waypoint dictionary with minimal required fields
     """
     return {
-        "id": 0,
+        "id": 1,
         "name": "Test Waypoint",
         "latitude": -35.363261,
         "longitude": 149.165230,
         "altitude": 50.0,
-        "command": "WAYPOINT",
-        "param1": 0,
-        "param2": 0,
-        "param3": 0,
-        "param4": 0
     }
 
 
@@ -128,23 +126,29 @@ def sample_waypoint():
 def sample_waypoints():
     """Provide a list of sample waypoints for testing.
 
+    Uses minimal required fields plus altitude. Tests that waypoints
+    work without specifying command or param fields.
+
     Returns:
-        list: List of waypoint dictionaries with valid test data
+        list: List of waypoint dictionaries with minimal fields
     """
     return [
         {
+            "id": 1,
             "name": "WP1",
             "latitude": -35.363261,
             "longitude": 149.165230,
             "altitude": 50.0,
         },
         {
+            "id": 2,
             "name": "WP2",
             "latitude": -35.363361,
             "longitude": 149.165330,
             "altitude": 55.0,
         },
         {
+            "id": 3,
             "name": "WP3",
             "latitude": -35.363461,
             "longitude": 149.165430,

--- a/projects/mission-planner/api_spec.yml
+++ b/projects/mission-planner/api_spec.yml
@@ -380,36 +380,55 @@ components:
   schemas:
     Waypoint:
       type: object
+      required:
+        - id
+        - name
+        - latitude
+        - longitude
       properties:
         id:
           type: number
           format: integer
+          description: "Waypoint identifier"
         name:
           type: string
-        longitude:
-          type: number
-          format: float64
+          description: "Waypoint name (note: not preserved through MAVLink protocol, will be regenerated as 'Mission Waypoint N')"
         latitude:
           type: number
           format: float64
+          description: "Latitude in decimal degrees"
+        longitude:
+          type: number
+          format: float64
+          description: "Longitude in decimal degrees"
         altitude:
           type: number
           format: float64
+          description: "Altitude in meters MSL. If omitted, uses previous waypoint's altitude (or 50m for first waypoint)"
         command:
           type: string
-          description: "Put the waypoint command here as in MissionPlanner, i.e., `LOITER_UNLIM` or `DO_CHANGE_SPEED`. Default value: `WAYPOINT`"
+          description: "MAVLink command type (e.g., 'WAYPOINT', 'LOITER_UNLIM', 'DO_CHANGE_SPEED'). Default: 'WAYPOINT'"
+          default: "WAYPOINT"
         param1:
           type: number
-          format: integer
+          format: float
+          description: "Command parameter 1. For WAYPOINT: hold time in seconds (multicopter only). Default: 0"
+          default: 0
         param2:
           type: number
-          format: integer
+          format: float
+          description: "Command parameter 2. For WAYPOINT: acceptance radius in meters (NOTE: ignored by ArduPilot, use WPNAV_RADIUS parameter instead). Default: 0"
+          default: 0
         param3:
           type: number
-          format: integer
+          format: float
+          description: "Command parameter 3. For WAYPOINT: pass-through radius (NOTE: ignored by ArduPilot). Default: 0"
+          default: 0
         param4:
           type: number
-          format: integer
+          format: float
+          description: "Command parameter 4. For WAYPOINT: desired yaw angle (NOTE: ignored by ArduPilot in most cases). Default: 0"
+          default: 0
     Status:
       type: object
       properties:


### PR DESCRIPTION
# Description

Fixed integration tests to properly handle MAVLink's home waypoint behavior and improved API specification for waypoint fields.

MAVLink missions always include a home waypoint at sequence 0, but the integration tests were not accounting for this. This caused tests to fail when checking queue lengths and waypoint matches. This PR updates:

1. Test assertions to expect home waypoint in queue (queue + 1 waypoint counts)
2. Waypoint comparison logic to skip home waypoint when validating uploads
3. API spec to clearly document required vs optional fields with defaults
4. Sample test fixtures to use minimal required fields with proper structure

The changes ensure tests accurately reflect MAVLink protocol behavior while maintaining test coverage for waypoint upload, retrieval, and persistence functionality.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

# How Has This Been Tested?

- [x] Integration tests for waypoint upload/retrieval
- [x] Queue persistence tests
- [x] Waypoint overwrite tests
- [x] Empty queue validation

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules