### PR TITLE
Throw errors for missing env vars

### DIFF
--- a/projects/web-backend/src/gcom/settings.py
+++ b/projects/web-backend/src/gcom/settings.py
@@ -26,9 +26,14 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = os.getenv("SECRET_KEY")
+if not SECRET_KEY:
+    raise ValueError(
+        "SECRET_KEY environment variable is not set. "
+        "Please copy .env.example to .env and configure it with your values."
+    )
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.getenv("DEBUG")
+DEBUG = os.getenv("DEBUG", "False").lower() in ("true", "1", "yes")
 
 CORS_ALLOW_ALL_ORIGINS = True
 CORS_ALLOW_HEADERS = "*"

--- a/projects/web-frontend/src/components/Map/MapView.tsx
+++ b/projects/web-frontend/src/components/Map/MapView.tsx
@@ -11,6 +11,7 @@ import {
 import { selectAircraftStatus, selectMPSWaypoints } from "../../store/slices/dataSlice";
 import { useAppDispatch, useAppSelector } from "../../store/store";
 import WaypointItem from "../WaypointItem";
+import { MAPTILER_API_KEY } from "../../constants";
 
 export default function MapView() {
     const mpsWaypoints = useAppSelector(selectMPSWaypoints);
@@ -18,7 +19,6 @@ export default function MapView() {
     const aircraftStatus = useAppSelector(selectAircraftStatus);
     const coords = useAppSelector(selectMapCenterCoords);
     const dispatch = useAppDispatch();
-    const KEY = import.meta.env.VITE_MAPTILER_KEY as string;
 
     useEffect(() => {
         dispatch(initializeMpsWaypointMapState(mpsWaypoints.length));
@@ -52,7 +52,7 @@ export default function MapView() {
                 }}
                 mapStyle={
                     window.navigator.onLine
-                        ? `https://api.maptiler.com/maps/basic-v2/style.json?key=${KEY}`
+                        ? `https://api.maptiler.com/maps/basic-v2/style.json?key=${MAPTILER_API_KEY}`
                         : "http://localhost:8000/api/map-tiles/osmbright"
                 }
                 doubleClickZoom={false}

--- a/projects/web-frontend/src/components/Map/WaypointCreationMap.tsx
+++ b/projects/web-frontend/src/components/Map/WaypointCreationMap.tsx
@@ -14,6 +14,7 @@ import WaypointItem from "../WaypointItem";
 import { roundTo } from "../../utils/routeTo";
 import { Box } from "@mui/material";
 import { WaypointEditState } from "../../types/Waypoint";
+import { MAPTILER_API_KEY } from "../../constants";
 
 type DraggedMarker = {
     long: number;
@@ -33,7 +34,6 @@ export default function WaypointCreationMap({ handleDelete, handleEdit, editStat
     const dispatch = useAppDispatch();
     const [selectedWaypoints, setSelectedWaypoints] = useState<boolean[]>(clientWPQueue.map(() => false));
     const [draggedMarkerData, setDraggedMarkerData] = useState<DraggedMarker | null>(null);
-    const KEY = import.meta.env.VITE_MAPTILER_KEY as string;
 
     const routeData: GeoJSON.GeoJSON = {
         type: "LineString",
@@ -77,7 +77,7 @@ export default function WaypointCreationMap({ handleDelete, handleEdit, editStat
             }}
             mapStyle={
                 window.navigator.onLine
-                    ? `https://api.maptiler.com/maps/basic-v2/style.json?key=${KEY}`
+                    ? `https://api.maptiler.com/maps/basic-v2/style.json?key=${MAPTILER_API_KEY}`
                     : "./src/mapStyles/osmbright.json"
             }
             onClick={createNewWaypoint}

--- a/projects/web-frontend/src/constants.ts
+++ b/projects/web-frontend/src/constants.ts
@@ -1,0 +1,10 @@
+const VITE_MAPTILER_KEY = import.meta.env.VITE_MAPTILER_KEY;
+
+if (!VITE_MAPTILER_KEY && window.navigator.onLine) {
+    throw new Error(
+        "VITE_MAPTILER_KEY environment variable is not set. " +
+        "Please copy .env.example to .env and configure it with your MapTiler API key."
+    );
+}
+
+export const MAPTILER_API_KEY = VITE_MAPTILER_KEY as string;


### PR DESCRIPTION
# Description

Adds validation and error handling for missing environment variables in both backend and frontend to prevent cryptic errors and silent failures.

**Backend changes:**
- Added validation for `SECRET_KEY` in `settings.py` that throws a clear `ValueError` on startup if missing
- Fixed `DEBUG` env var parsing to properly handle boolean values (was previously returning string/None)

**Frontend changes:**
- Created `src/constants.ts` to centralize all environment variable access
- Moved `VITE_MAPTILER_KEY` validation into constants file (validates once at module load)
- Updated `MapView.tsx` and `WaypointCreationMap.tsx` to use centralized constant
- Validation only runs when online (offline mode uses local map tiles)

## Type of change

What types of changes does your code introduce to this project?
_Put an \`x\` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

# How Has This Been Tested?

- [x] Tested backend startup with missing SECRET_KEY (throws clear error message)
- [x] Tested backend startup with DEBUG=True/False/1/0 (properly parses boolean)
- [x] Tested frontend with missing VITE_MAPTILER_KEY while online (throws clear error message)
- [x] Tested frontend with missing VITE_MAPTILER_KEY while offline (works fine with local tiles)

## Checklist

_Put an \`x\` in the boxes that apply. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules