### PR TITLE
Standardize coordinate field names from lat/long to latitude/longitude

### DIFF
--- a/projects/integration-tests/conftest.py
+++ b/projects/integration-tests/conftest.py
@@ -145,3 +145,82 @@ def sample_waypoints():
             "altitude": 60.0,
         },
     ]
+
+
+@pytest.fixture
+def sample_route_data():
+    """Provide sample route data for testing.
+
+    Returns:
+        dict: Route dictionary with name
+    """
+    return {"name": "Test Route"}
+
+
+@pytest.fixture
+def sample_waypoint_db_data():
+    """Provide a sample waypoint for database testing.
+
+    This includes fields specific to database waypoints (OrderedWaypoint).
+    Note: 'route' field should be added when creating waypoint.
+
+    Returns:
+        dict: Waypoint dictionary with database-specific fields
+    """
+    return {
+        "name": "TestWP1",
+        "latitude": -35.363261,
+        "longitude": 149.165230,
+        "altitude": 50.0,
+        "radius": 5.0,
+        "pass_radius": 5.0,
+        "pass_option": 0,
+        "order": 0,
+    }
+
+
+@pytest.fixture(autouse=True)
+def reset_database_state(api_client):
+    """Reset database state before and after each test.
+
+    This fixture runs automatically before every test to ensure a clean database.
+    It clears all routes (which cascades to waypoints) and individual waypoints.
+
+    Args:
+        api_client: API client from fixture
+
+    Yields:
+        None: Control returns to test after setup
+    """
+    # Setup: Clear database before test
+    try:
+        # Delete all routes (cascades to waypoints)
+        routes = api_client.list_routes()
+        for route in routes:
+            api_client.delete_route(route["id"])
+
+        # Delete any orphaned waypoints
+        waypoints = api_client.list_waypoints()
+        for waypoint in waypoints:
+            api_client.delete_waypoint(waypoint["id"])
+    except Exception as e:
+        # Log but don't fail on cleanup errors
+        print(f"Warning: Database cleanup failed during setup: {e}")
+
+    # Run the test
+    yield
+
+    # Teardown: Clean up after test
+    try:
+        # Delete all routes (cascades to waypoints)
+        routes = api_client.list_routes()
+        for route in routes:
+            api_client.delete_route(route["id"])
+
+        # Delete any orphaned waypoints
+        waypoints = api_client.list_waypoints()
+        for waypoint in waypoints:
+            api_client.delete_waypoint(waypoint["id"])
+    except Exception as e:
+        # Log but don't fail on cleanup errors
+        print(f"Warning: Database cleanup failed during teardown: {e}")

--- a/projects/integration-tests/helpers/__init__.py
+++ b/projects/integration-tests/helpers/__init__.py
@@ -18,6 +18,9 @@ from .assertions import (
     assert_queue_not_empty,
     assert_field_values_match,
     assert_queue_upload_successful,
+    assert_waypoint_db_match,
+    assert_route_contains_waypoints,
+    assert_waypoints_ordered,
 )
 
 __all__ = [
@@ -36,4 +39,7 @@ __all__ = [
     "assert_queue_not_empty",
     "assert_field_values_match",
     "assert_queue_upload_successful",
+    "assert_waypoint_db_match",
+    "assert_route_contains_waypoints",
+    "assert_waypoints_ordered",
 ]

--- a/projects/integration-tests/helpers/api_client.py
+++ b/projects/integration-tests/helpers/api_client.py
@@ -164,6 +164,165 @@ class APIClient:
         )
         return response
 
+    # ==================== Database Waypoint API Methods ====================
+    # These methods interact with the web-backend's database for mission planning.
+    # Waypoints stored here are for planning and can be loaded to the drone later.
+
+    def create_waypoint(self, waypoint_data: Dict[str, Any]) -> Response:
+        """Create a waypoint in the database.
+
+        Args:
+            waypoint_data: Waypoint dictionary with required fields
+
+        Returns:
+            Response object
+        """
+        response = requests.post(
+            f"{self.web_backend_url}/api/waypoint/",
+            json=waypoint_data,
+            headers={"Content-Type": "application/json"},
+        )
+        return response
+
+    def list_waypoints(self) -> List[Dict[str, Any]]:
+        """List all waypoints from the database.
+
+        Returns:
+            List of waypoint dictionaries
+        """
+        response = requests.get(f"{self.web_backend_url}/api/waypoint/")
+        response.raise_for_status()
+        return response.json()
+
+    def get_waypoint(self, waypoint_id: str) -> Dict[str, Any]:
+        """Get a specific waypoint from the database by ID.
+
+        Args:
+            waypoint_id: UUID of the waypoint
+
+        Returns:
+            Waypoint dictionary
+        """
+        response = requests.get(f"{self.web_backend_url}/api/waypoint/{waypoint_id}/")
+        response.raise_for_status()
+        return response.json()
+
+    def update_waypoint(self, waypoint_id: str, data: Dict[str, Any]) -> Response:
+        """Update a waypoint in the database (full update).
+
+        Args:
+            waypoint_id: UUID of the waypoint
+            data: Complete waypoint data
+
+        Returns:
+            Response object
+        """
+        response = requests.put(
+            f"{self.web_backend_url}/api/waypoint/{waypoint_id}/",
+            json=data,
+            headers={"Content-Type": "application/json"},
+        )
+        return response
+
+    def partial_update_waypoint(self, waypoint_id: str, data: Dict[str, Any]) -> Response:
+        """Partially update a waypoint in the database.
+
+        Args:
+            waypoint_id: UUID of the waypoint
+            data: Partial waypoint data to update
+
+        Returns:
+            Response object
+        """
+        response = requests.patch(
+            f"{self.web_backend_url}/api/waypoint/{waypoint_id}/",
+            json=data,
+            headers={"Content-Type": "application/json"},
+        )
+        return response
+
+    def delete_waypoint(self, waypoint_id: str) -> Response:
+        """Delete a waypoint from the database.
+
+        Args:
+            waypoint_id: UUID of the waypoint
+
+        Returns:
+            Response object
+        """
+        response = requests.delete(f"{self.web_backend_url}/api/waypoint/{waypoint_id}/")
+        return response
+
+    # ==================== Database Route API Methods ====================
+
+    def create_route(self, route_data: Dict[str, Any]) -> Response:
+        """Create a route in the database.
+
+        Args:
+            route_data: Route dictionary (typically just {"name": "Route Name"})
+
+        Returns:
+            Response object
+        """
+        response = requests.post(
+            f"{self.web_backend_url}/api/route/",
+            json=route_data,
+            headers={"Content-Type": "application/json"},
+        )
+        return response
+
+    def list_routes(self) -> List[Dict[str, Any]]:
+        """List all routes from the database.
+
+        Returns:
+            List of route dictionaries with nested waypoints
+        """
+        response = requests.get(f"{self.web_backend_url}/api/route/")
+        response.raise_for_status()
+        return response.json()
+
+    def get_route(self, route_id: int) -> Dict[str, Any]:
+        """Get a specific route from the database by ID.
+
+        Args:
+            route_id: Integer ID of the route
+
+        Returns:
+            Route dictionary with nested waypoints
+        """
+        response = requests.get(f"{self.web_backend_url}/api/route/{route_id}/")
+        response.raise_for_status()
+        return response.json()
+
+    def delete_route(self, route_id: int) -> Response:
+        """Delete a route from the database.
+
+        Args:
+            route_id: Integer ID of the route
+
+        Returns:
+            Response object
+        """
+        response = requests.delete(f"{self.web_backend_url}/api/route/{route_id}/")
+        return response
+
+    def reorder_route_waypoints(self, route_id: int, waypoint_ids: List[str]) -> Response:
+        """Reorder waypoints within a route.
+
+        Args:
+            route_id: Integer ID of the route
+            waypoint_ids: List of waypoint UUIDs in desired order
+
+        Returns:
+            Response object
+        """
+        response = requests.post(
+            f"{self.web_backend_url}/api/route/{route_id}/reorder-waypoints/",
+            json=waypoint_ids,
+            headers={"Content-Type": "application/json"},
+        )
+        return response
+
     # ==================== Mission-Planner Direct Access ====================
     # These methods bypass web-backend and hit mission-planner directly.
     # Use sparingly - only for verification or debugging, not primary test flow.

--- a/projects/integration-tests/helpers/assertions.py
+++ b/projects/integration-tests/helpers/assertions.py
@@ -257,3 +257,98 @@ def assert_queue_upload_successful(
     queue = api_client.get_queue()
     assert_waypoints_match(queue, waypoints)
     return queue
+
+
+def assert_waypoint_db_match(
+    actual: Dict[str, Any],
+    expected: Dict[str, Any],
+    ignore_id: bool = True,
+) -> None:
+    """Assert that database waypoint matches expected values.
+
+    Compares waypoints from database API responses. Handles UUID fields
+    and database-specific fields like order, route, radius, etc.
+
+    Args:
+        actual: Actual waypoint from database API
+        expected: Expected waypoint values
+        ignore_id: If True, skip comparing the 'id' field (useful for new waypoints)
+
+    Raises:
+        AssertionError: If waypoints don't match
+    """
+    check_fields = ["name", "latitude", "longitude", "altitude"]
+
+    # Add database-specific fields if present in expected
+    if "order" in expected:
+        check_fields.append("order")
+    if "route" in expected:
+        check_fields.append("route")
+    if "radius" in expected:
+        check_fields.append("radius")
+    if "pass_radius" in expected:
+        check_fields.append("pass_radius")
+    if "pass_option" in expected:
+        check_fields.append("pass_option")
+
+    for field in check_fields:
+        if field in expected:
+            assert field in actual, f"Waypoint missing field: {field}"
+            actual_value = actual[field]
+            expected_value = expected[field]
+
+            # For floating point fields, allow small tolerance
+            if field in ["latitude", "longitude", "altitude", "radius", "pass_radius"]:
+                tolerance = 0.0001
+                assert (
+                    abs(actual_value - expected_value) < tolerance
+                ), f"Waypoint {field} mismatch: {actual_value} != {expected_value}"
+            else:
+                assert (
+                    actual_value == expected_value
+                ), f"Waypoint {field} mismatch: {actual_value} != {expected_value}"
+
+    # Check ID exists if not ignoring it
+    if not ignore_id:
+        assert "id" in actual, "Waypoint missing 'id' field"
+
+
+def assert_route_contains_waypoints(
+    route: Dict[str, Any],
+    expected_count: int,
+) -> None:
+    """Assert that route contains expected number of waypoints.
+
+    Args:
+        route: Route dictionary from API (should include 'waypoints' field)
+        expected_count: Expected number of waypoints in the route
+
+    Raises:
+        AssertionError: If waypoint count doesn't match
+    """
+    assert "waypoints" in route, "Route missing 'waypoints' field"
+    waypoints = route["waypoints"]
+    actual_count = len(waypoints)
+
+    assert (
+        actual_count == expected_count
+    ), f"Route waypoint count mismatch: {actual_count} != {expected_count}"
+
+
+def assert_waypoints_ordered(waypoints: List[Dict[str, Any]]) -> None:
+    """Assert that waypoints are in correct order (0, 1, 2, ...).
+
+    Verifies that the 'order' field in each waypoint is sequential starting from 0.
+
+    Args:
+        waypoints: List of waypoint dictionaries with 'order' field
+
+    Raises:
+        AssertionError: If waypoints are not in correct order
+    """
+    for i, waypoint in enumerate(waypoints):
+        assert "order" in waypoint, f"Waypoint {i} missing 'order' field"
+        actual_order = waypoint["order"]
+        assert (
+            actual_order == i
+        ), f"Waypoint order mismatch at index {i}: {actual_order} != {i}"

--- a/projects/integration-tests/tests/test_waypoint_api.py
+++ b/projects/integration-tests/tests/test_waypoint_api.py
@@ -1,0 +1,475 @@
+"""Integration tests for waypoint and route database API endpoints.
+
+These tests verify database CRUD operations for waypoints and routes,
+as well as integration between database waypoints and drone queue operations.
+"""
+
+import pytest
+from helpers import (
+    assert_waypoint_db_match,
+    assert_route_contains_waypoints,
+    assert_waypoints_ordered,
+    assert_waypoints_match,
+)
+
+
+@pytest.mark.critical
+def test_create_single_waypoint(api_client, sample_waypoint_db_data, sample_route_data):
+    """Test creating a single waypoint in the database.
+
+    Args:
+        api_client: API client fixture
+        sample_waypoint_db_data: Sample waypoint data fixture
+        sample_route_data: Sample route data fixture
+    """
+    # Create a route first (waypoints need to belong to a route)
+    route_response = api_client.create_route(sample_route_data)
+    assert route_response.status_code == 201, f"Failed to create route: {route_response.text}"
+    route = route_response.json()
+
+    # Add route to waypoint data
+    waypoint_data = {**sample_waypoint_db_data, "route": route["id"]}
+
+    # Act: Create waypoint
+    response = api_client.create_waypoint(waypoint_data)
+
+    # Assert: Verify creation
+    assert response.status_code == 201, f"Failed to create waypoint: {response.text}"
+    created_waypoint = response.json()
+
+    # Verify returned waypoint has ID and matches input
+    assert "id" in created_waypoint, "Created waypoint missing 'id' field"
+    assert_waypoint_db_match(created_waypoint, waypoint_data)
+
+    # Verify persistence by retrieving
+    retrieved_waypoint = api_client.get_waypoint(created_waypoint["id"])
+    assert_waypoint_db_match(retrieved_waypoint, waypoint_data)
+
+
+def test_create_multiple_waypoints(api_client, sample_route_data):
+    """Test creating multiple waypoints in the database.
+
+    Args:
+        api_client: API client fixture
+        sample_route_data: Sample route data fixture
+    """
+    # Create a route first
+    route_response = api_client.create_route(sample_route_data)
+    assert route_response.status_code == 201
+    route = route_response.json()
+
+    # Create multiple waypoints
+    waypoints_data = [
+        {
+            "name": f"WP{i}",
+            "latitude": -35.363261 + (i * 0.001),
+            "longitude": 149.165230 + (i * 0.001),
+            "altitude": 50.0 + (i * 5),
+            "order": i,
+            "route": route["id"],
+            "radius": 5.0,
+            "pass_radius": 5.0,
+            "pass_option": 0,
+        }
+        for i in range(3)
+    ]
+
+    created_waypoints = []
+    for wp_data in waypoints_data:
+        response = api_client.create_waypoint(wp_data)
+        assert response.status_code == 201, f"Failed to create waypoint: {response.text}"
+        created_waypoints.append(response.json())
+
+    # Verify all waypoints exist
+    all_waypoints = api_client.list_waypoints()
+    assert len(all_waypoints) >= 3, f"Expected at least 3 waypoints, found {len(all_waypoints)}"
+
+    # Verify each created waypoint
+    for created, expected in zip(created_waypoints, waypoints_data):
+        assert_waypoint_db_match(created, expected)
+
+
+def test_list_waypoints(api_client, sample_route_data):
+    """Test listing all waypoints from the database.
+
+    Args:
+        api_client: API client fixture
+        sample_route_data: Sample route data fixture
+    """
+    # Create a route
+    route_response = api_client.create_route(sample_route_data)
+    route = route_response.json()
+
+    # Create several waypoints
+    num_waypoints = 4
+    for i in range(num_waypoints):
+        waypoint_data = {
+            "name": f"ListWP{i}",
+            "latitude": -35.363261 + (i * 0.001),
+            "longitude": 149.165230 + (i * 0.001),
+            "altitude": 50.0,
+            "order": i,
+            "route": route["id"],
+        }
+        response = api_client.create_waypoint(waypoint_data)
+        assert response.status_code == 201
+
+    # Act: List all waypoints
+    waypoints = api_client.list_waypoints()
+
+    # Assert: Verify all are present
+    assert len(waypoints) >= num_waypoints, f"Expected at least {num_waypoints} waypoints"
+    waypoint_names = [wp["name"] for wp in waypoints]
+    for i in range(num_waypoints):
+        assert f"ListWP{i}" in waypoint_names
+
+
+def test_get_waypoint_by_id(api_client, sample_waypoint_db_data, sample_route_data):
+    """Test retrieving a specific waypoint by ID.
+
+    Args:
+        api_client: API client fixture
+        sample_waypoint_db_data: Sample waypoint data fixture
+        sample_route_data: Sample route data fixture
+    """
+    # Create route and waypoint
+    route_response = api_client.create_route(sample_route_data)
+    route = route_response.json()
+
+    waypoint_data = {**sample_waypoint_db_data, "route": route["id"]}
+    create_response = api_client.create_waypoint(waypoint_data)
+    created_waypoint = create_response.json()
+
+    # Act: Get waypoint by ID
+    retrieved_waypoint = api_client.get_waypoint(created_waypoint["id"])
+
+    # Assert: Verify exact match
+    assert_waypoint_db_match(retrieved_waypoint, waypoint_data)
+    assert retrieved_waypoint["id"] == created_waypoint["id"]
+
+
+def test_update_waypoint(api_client, sample_waypoint_db_data, sample_route_data):
+    """Test updating a waypoint's data.
+
+    Args:
+        api_client: API client fixture
+        sample_waypoint_db_data: Sample waypoint data fixture
+        sample_route_data: Sample route data fixture
+    """
+    # Create route and waypoint
+    route_response = api_client.create_route(sample_route_data)
+    route = route_response.json()
+
+    waypoint_data = {**sample_waypoint_db_data, "route": route["id"]}
+    create_response = api_client.create_waypoint(waypoint_data)
+    waypoint = create_response.json()
+
+    # Modify waypoint data
+    updated_data = {
+        **waypoint_data,
+        "name": "UpdatedWP",
+        "altitude": 100.0,
+        "latitude": -35.400000,
+    }
+
+    # Act: Update waypoint
+    update_response = api_client.partial_update_waypoint(waypoint["id"], updated_data)
+
+    # Assert: Verify update succeeded
+    assert update_response.status_code == 200, f"Failed to update waypoint: {update_response.text}"
+
+    # Verify changes persisted
+    retrieved_waypoint = api_client.get_waypoint(waypoint["id"])
+    assert retrieved_waypoint["name"] == "UpdatedWP"
+    assert abs(retrieved_waypoint["altitude"] - 100.0) < 0.001
+    assert abs(retrieved_waypoint["latitude"] - (-35.400000)) < 0.0001
+
+
+def test_delete_waypoint(api_client, sample_waypoint_db_data, sample_route_data):
+    """Test deleting a waypoint from the database.
+
+    Args:
+        api_client: API client fixture
+        sample_waypoint_db_data: Sample waypoint data fixture
+        sample_route_data: Sample route data fixture
+    """
+    # Create route and waypoint
+    route_response = api_client.create_route(sample_route_data)
+    route = route_response.json()
+
+    waypoint_data = {**sample_waypoint_db_data, "route": route["id"]}
+    create_response = api_client.create_waypoint(waypoint_data)
+    waypoint = create_response.json()
+
+    # Act: Delete waypoint
+    delete_response = api_client.delete_waypoint(waypoint["id"])
+
+    # Assert: Verify deletion
+    assert delete_response.status_code == 204, f"Failed to delete waypoint: {delete_response.text}"
+
+    # Verify waypoint no longer exists (should get 404)
+    try:
+        api_client.get_waypoint(waypoint["id"])
+        pytest.fail("Expected 404 when getting deleted waypoint")
+    except Exception as e:
+        assert "404" in str(e), f"Expected 404 error, got: {e}"
+
+
+def test_create_route_with_waypoints(api_client, sample_route_data):
+    """Test creating a route with multiple waypoints and verify nested structure.
+
+    Args:
+        api_client: API client fixture
+        sample_route_data: Sample route data fixture
+    """
+    # Create route
+    route_response = api_client.create_route(sample_route_data)
+    assert route_response.status_code == 201
+    route = route_response.json()
+
+    # Create waypoints for the route
+    num_waypoints = 3
+    for i in range(num_waypoints):
+        waypoint_data = {
+            "name": f"RouteWP{i}",
+            "latitude": -35.363261 + (i * 0.001),
+            "longitude": 149.165230 + (i * 0.001),
+            "altitude": 50.0,
+            "order": i,
+            "route": route["id"],
+        }
+        response = api_client.create_waypoint(waypoint_data)
+        assert response.status_code == 201
+
+    # Act: Get route with nested waypoints
+    retrieved_route = api_client.get_route(route["id"])
+
+    # Assert: Verify route contains waypoints
+    assert_route_contains_waypoints(retrieved_route, num_waypoints)
+    assert_waypoints_ordered(retrieved_route["waypoints"])
+
+
+def test_reorder_waypoints_in_route(api_client, sample_route_data):
+    """Test reordering waypoints within a route.
+
+    Args:
+        api_client: API client fixture
+        sample_route_data: Sample route data fixture
+    """
+    # Create route
+    route_response = api_client.create_route(sample_route_data)
+    route = route_response.json()
+
+    # Create 4 waypoints in order
+    waypoint_ids = []
+    for i in range(4):
+        waypoint_data = {
+            "name": f"OrderWP{i}",
+            "latitude": -35.363261 + (i * 0.001),
+            "longitude": 149.165230 + (i * 0.001),
+            "altitude": 50.0,
+            "order": i,
+            "route": route["id"],
+        }
+        response = api_client.create_waypoint(waypoint_data)
+        waypoint = response.json()
+        waypoint_ids.append(waypoint["id"])
+
+    # Act: Reorder waypoints [0,1,2,3] -> [3,1,0,2]
+    new_order = [waypoint_ids[3], waypoint_ids[1], waypoint_ids[0], waypoint_ids[2]]
+    reorder_response = api_client.reorder_route_waypoints(route["id"], new_order)
+
+    # Assert: Verify reorder succeeded
+    assert reorder_response.status_code == 200, f"Failed to reorder: {reorder_response.text}"
+
+    # Verify new order
+    retrieved_route = api_client.get_route(route["id"])
+    waypoints = retrieved_route["waypoints"]
+
+    assert len(waypoints) == 4
+    assert waypoints[0]["id"] == waypoint_ids[3]
+    assert waypoints[1]["id"] == waypoint_ids[1]
+    assert waypoints[2]["id"] == waypoint_ids[0]
+    assert waypoints[3]["id"] == waypoint_ids[2]
+
+    # Verify order field is updated correctly
+    assert_waypoints_ordered(waypoints)
+
+
+def test_delete_route_cascades_to_waypoints(api_client, sample_route_data):
+    """Test that deleting a route also deletes its waypoints (cascade).
+
+    Args:
+        api_client: API client fixture
+        sample_route_data: Sample route data fixture
+    """
+    # Create route with waypoints
+    route_response = api_client.create_route(sample_route_data)
+    route = route_response.json()
+
+    waypoint_ids = []
+    for i in range(3):
+        waypoint_data = {
+            "name": f"CascadeWP{i}",
+            "latitude": -35.363261 + (i * 0.001),
+            "longitude": 149.165230 + (i * 0.001),
+            "altitude": 50.0,
+            "order": i,
+            "route": route["id"],
+        }
+        response = api_client.create_waypoint(waypoint_data)
+        waypoint = response.json()
+        waypoint_ids.append(waypoint["id"])
+
+    # Act: Delete route
+    delete_response = api_client.delete_route(route["id"])
+    assert delete_response.status_code == 204
+
+    # Assert: Verify waypoints are also deleted
+    for waypoint_id in waypoint_ids:
+        try:
+            api_client.get_waypoint(waypoint_id)
+            pytest.fail(f"Expected waypoint {waypoint_id} to be deleted with route")
+        except Exception as e:
+            assert "404" in str(e), f"Expected 404 error for waypoint {waypoint_id}"
+
+
+def test_waypoint_validation(api_client, sample_route_data):
+    """Test that invalid waypoint data is rejected with appropriate errors.
+
+    Args:
+        api_client: API client fixture
+        sample_route_data: Sample route data fixture
+    """
+    # Create route
+    route_response = api_client.create_route(sample_route_data)
+    route = route_response.json()
+
+    # Test missing required fields
+    incomplete_waypoint = {
+        "name": "IncompleteWP",
+        # Missing latitude, longitude, altitude (required fields)
+        "order": 0,
+        "route": route["id"],
+    }
+
+    response = api_client.create_waypoint(incomplete_waypoint)
+    assert response.status_code == 400, "Expected 400 for missing required fields"
+
+
+def test_load_saved_route_to_drone(api_client, sample_route_data):
+    """Test loading a saved route from database to drone queue.
+
+    This test verifies the integration between database waypoints and drone control:
+    1. Create route with waypoints in database
+    2. Retrieve route
+    3. Transform waypoints to drone format
+    4. Load to drone queue
+    5. Verify drone has the waypoints
+
+    Args:
+        api_client: API client fixture
+        sample_route_data: Sample route data fixture
+    """
+    # Step 1: Create route in database
+    route_response = api_client.create_route(sample_route_data)
+    route = route_response.json()
+
+    # Create waypoints in database
+    db_waypoints_data = []
+    for i in range(3):
+        waypoint_data = {
+            "name": f"DroneWP{i}",
+            "latitude": -35.363261 + (i * 0.001),
+            "longitude": 149.165230 + (i * 0.001),
+            "altitude": 50.0 + (i * 5),
+            "order": i,
+            "route": route["id"],
+            "radius": 5.0,
+            "pass_radius": 5.0,
+            "pass_option": 0,
+        }
+        response = api_client.create_waypoint(waypoint_data)
+        assert response.status_code == 201
+        db_waypoints_data.append(waypoint_data)
+
+    # Step 2: Retrieve route from database
+    retrieved_route = api_client.get_route(route["id"])
+    assert_route_contains_waypoints(retrieved_route, 3)
+
+    # Step 3: Transform database waypoints to drone format
+    # Drone waypoints only need: name, latitude, longitude, altitude
+    drone_waypoints = [
+        {
+            "name": wp["name"],
+            "latitude": wp["latitude"],
+            "longitude": wp["longitude"],
+            "altitude": wp["altitude"],
+        }
+        for wp in retrieved_route["waypoints"]
+    ]
+
+    # Step 4: Load to drone queue
+    upload_response = api_client.post_queue(drone_waypoints)
+    assert upload_response.status_code == 200, f"Failed to upload to drone: {upload_response.text}"
+
+    # Step 5: Verify drone queue
+    drone_queue = api_client.get_queue()
+    assert_waypoints_match(drone_queue, drone_waypoints)
+
+
+def test_load_empty_route_to_drone(api_client, sample_route_data):
+    """Test loading an empty route to the drone queue.
+
+    Args:
+        api_client: API client fixture
+        sample_route_data: Sample route data fixture
+    """
+    # Create route with no waypoints
+    route_response = api_client.create_route(sample_route_data)
+    route = route_response.json()
+
+    # Retrieve empty route
+    retrieved_route = api_client.get_route(route["id"])
+    assert_route_contains_waypoints(retrieved_route, 0)
+
+    # Attempt to load empty route to drone
+    drone_waypoints = []
+    upload_response = api_client.post_queue(drone_waypoints)
+
+    # Should accept empty queue (clearing the queue)
+    assert upload_response.status_code == 200, "Should accept empty waypoint list"
+
+    # Verify drone queue is empty
+    drone_queue = api_client.get_queue()
+    assert len(drone_queue) == 0, "Drone queue should be empty"
+
+
+def test_waypoint_not_found_error(api_client):
+    """Test that accessing non-existent waypoint returns 404.
+
+    Args:
+        api_client: API client fixture
+    """
+    fake_uuid = "00000000-0000-0000-0000-000000000000"
+
+    # Test GET
+    try:
+        api_client.get_waypoint(fake_uuid)
+        pytest.fail("Expected 404 when getting non-existent waypoint")
+    except Exception as e:
+        assert "404" in str(e), f"Expected 404 error, got: {e}"
+
+    # Test DELETE
+    delete_response = api_client.delete_waypoint(fake_uuid)
+    assert delete_response.status_code == 404, "Expected 404 for delete on non-existent waypoint"
+
+    # Test UPDATE
+    update_data = {
+        "name": "UpdatedWP",
+        "latitude": -35.363261,
+        "longitude": 149.165230,
+        "altitude": 50.0,
+    }
+    update_response = api_client.partial_update_waypoint(fake_uuid, update_data)
+    assert update_response.status_code == 404, "Expected 404 for update on non-existent waypoint"

--- a/projects/web-frontend/src/components/Map/MapView.tsx
+++ b/projects/web-frontend/src/components/Map/MapView.tsx
@@ -26,7 +26,7 @@ export default function MapView() {
 
     const routeData: GeoJSON.GeoJSON = {
         type: "LineString",
-        coordinates: mpsWaypoints.map((waypoint) => [waypoint.long, waypoint.lat]),
+        coordinates: mpsWaypoints.map((waypoint) => [waypoint.longitude, waypoint.latitude]),
     };
     const routeStyle: LayerProps = {
         id: "mps-route",
@@ -46,8 +46,8 @@ export default function MapView() {
         >
             <Map
                 initialViewState={{
-                    longitude: coords.long,
-                    latitude: coords.lat,
+                    longitude: coords.longitude,
+                    latitude: coords.latitude,
                     zoom: 10,
                 }}
                 mapStyle={
@@ -60,8 +60,8 @@ export default function MapView() {
                 {mpsWaypoints.map((waypoint, i) => (
                     <Fragment key={i}>
                         <Marker
-                            latitude={waypoint.lat}
-                            longitude={waypoint.long}
+                            latitude={waypoint.latitude}
+                            longitude={waypoint.longitude}
                             onClick={() => dispatch(toggleMpsWaypointMapState(i))}
                             style={{
                                 cursor: "pointer",
@@ -93,7 +93,7 @@ export default function MapView() {
                             </Box>
                         </Marker>
                         {mpsWaypointMapState[i] && (
-                            <Marker latitude={waypoint.lat} longitude={waypoint.long}>
+                            <Marker latitude={waypoint.latitude} longitude={waypoint.longitude}>
                                 <WaypointItem
                                     sx={{
                                         position: "absolute",

--- a/projects/web-frontend/src/components/Map/WaypointCreationMap.tsx
+++ b/projects/web-frontend/src/components/Map/WaypointCreationMap.tsx
@@ -16,8 +16,8 @@ import { Box } from "@mui/material";
 import { WaypointEditState } from "../../types/Waypoint";
 
 type DraggedMarker = {
-    long: number;
-    lat: number;
+    longitude: number;
+    latitude: number;
     index: number;
 };
 
@@ -37,7 +37,7 @@ export default function WaypointCreationMap({ handleDelete, handleEdit, editStat
 
     const routeData: GeoJSON.GeoJSON = {
         type: "LineString",
-        coordinates: clientWPQueue.map((waypoint) => [waypoint.long, waypoint.lat]),
+        coordinates: clientWPQueue.map((waypoint) => [waypoint.longitude, waypoint.latitude]),
     };
     const routeStyle: LayerProps = {
         id: "mps-route",
@@ -53,8 +53,8 @@ export default function WaypointCreationMap({ handleDelete, handleEdit, editStat
         dispatch(
             addToQueuedWaypoints({
                 id: "-1",
-                lat: roundTo(event.lngLat.lat, 7),
-                long: roundTo(event.lngLat.lng, 7),
+                latitude: roundTo(event.lngLat.lat, 7),
+                longitude: roundTo(event.lngLat.lng, 7),
             }),
         );
         setSelectedWaypoints((prev) => [...prev, false]);
@@ -71,8 +71,8 @@ export default function WaypointCreationMap({ handleDelete, handleEdit, editStat
     return (
         <Map
             initialViewState={{
-                longitude: coords.long,
-                latitude: coords.lat,
+                longitude: coords.longitude,
+                latitude: coords.latitude,
                 zoom: 14,
             }}
             mapStyle={
@@ -97,8 +97,8 @@ export default function WaypointCreationMap({ handleDelete, handleEdit, editStat
                             }}
                             onDrag={(e) => {
                                 setDraggedMarkerData({
-                                    long: e.lngLat.lng,
-                                    lat: e.lngLat.lat,
+                                    longitude: e.lngLat.lng,
+                                    latitude: e.lngLat.lat,
                                     index: i,
                                 });
                             }}
@@ -108,8 +108,8 @@ export default function WaypointCreationMap({ handleDelete, handleEdit, editStat
                                         index: i,
                                         waypoint: {
                                             ...waypoint,
-                                            lat: roundTo(draggedMarkerData!.lat, 7),
-                                            long: roundTo(draggedMarkerData!.long, 7),
+                                            latitude: roundTo(draggedMarkerData!.latitude, 7),
+                                            longitude: roundTo(draggedMarkerData!.longitude, 7),
                                         },
                                     }),
                                 );
@@ -117,13 +117,13 @@ export default function WaypointCreationMap({ handleDelete, handleEdit, editStat
                             }}
                             latitude={
                                 draggedMarkerData && draggedMarkerData.index === i
-                                    ? draggedMarkerData.lat
-                                    : waypoint.lat
+                                    ? draggedMarkerData.latitude
+                                    : waypoint.latitude
                             }
                             longitude={
                                 draggedMarkerData && draggedMarkerData.index === i
-                                    ? draggedMarkerData.long
-                                    : waypoint.long
+                                    ? draggedMarkerData.longitude
+                                    : waypoint.longitude
                             }
                             style={{
                                 cursor: "pointer",
@@ -158,13 +158,13 @@ export default function WaypointCreationMap({ handleDelete, handleEdit, editStat
                             <Marker
                                 latitude={
                                     draggedMarkerData && draggedMarkerData.index === i
-                                        ? draggedMarkerData.lat
-                                        : waypoint.lat
+                                        ? draggedMarkerData.latitude
+                                        : waypoint.latitude
                                 }
                                 longitude={
                                     draggedMarkerData && draggedMarkerData.index === i
-                                        ? draggedMarkerData.long
-                                        : waypoint.long
+                                        ? draggedMarkerData.longitude
+                                        : waypoint.longitude
                                 }
                             >
                                 <WaypointItem

--- a/projects/web-frontend/src/components/WaypointItem.tsx
+++ b/projects/web-frontend/src/components/WaypointItem.tsx
@@ -39,7 +39,7 @@ export default function WaypointItem({ waypoint, sx, handleDelete, handleEdit }:
                         color: (theme) => theme.palette.primary.main,
                     }}
                 >
-                    {waypoint.lat}
+                    {waypoint.latitude}
                 </Typography>
             </Typography>
             <Typography variant="body1">
@@ -50,7 +50,7 @@ export default function WaypointItem({ waypoint, sx, handleDelete, handleEdit }:
                         color: (theme) => theme.palette.primary.main,
                     }}
                 >
-                    {waypoint.long}
+                    {waypoint.longitude}
                 </Typography>
             </Typography>
             <Typography variant="body1">

--- a/projects/web-frontend/src/components/WaypointStatus/WaypointForm.tsx
+++ b/projects/web-frontend/src/components/WaypointStatus/WaypointForm.tsx
@@ -14,8 +14,8 @@ type WaypointFormProps = {
 };
 
 const defaultFormState: FormState = {
-    lat: "",
-    long: "",
+    latitude: "",
+    longitude: "",
     alt: "",
     name: "",
     radius: "",
@@ -32,8 +32,8 @@ export default function WaypointForm({ editState, clearEditState }: WaypointForm
     const [formState, setFormState] = useState<FormState>(defaultFormState);
 
     const [formErrors, setFormErrors] = useState<FormErrors>({
-        lat: false,
-        long: false,
+        latitude: false,
+        longitude: false,
         alt: false,
     });
 
@@ -41,8 +41,8 @@ export default function WaypointForm({ editState, clearEditState }: WaypointForm
         if (editState.waypoint) {
             // TODO: bit ugly, could be improved in the future.
             setFormState({
-                lat: editState.waypoint.lat ? String(editState.waypoint.lat) : "",
-                long: editState.waypoint.long ? String(editState.waypoint.long) : "",
+                latitude: editState.waypoint.latitude ? String(editState.waypoint.latitude) : "",
+                longitude: editState.waypoint.longitude ? String(editState.waypoint.longitude) : "",
                 alt: editState.waypoint.alt ? String(editState.waypoint.alt) : "",
                 name: editState.waypoint.name ?? "No Name",
                 radius: editState.waypoint.radius ? String(editState.waypoint.radius) : "",
@@ -72,7 +72,9 @@ export default function WaypointForm({ editState, clearEditState }: WaypointForm
 
     const handleFormChange = (event: React.ChangeEvent<HTMLInputElement>) => {
         if (
-            ["lat", "long", "alt", "radius", "param1", "param2", "param3", "param4"].includes(event.target.id) &&
+            ["latitude", "longitude", "alt", "radius", "param1", "param2", "param3", "param4"].includes(
+                event.target.id,
+            ) &&
             /[^0-9.-]/.test(event.target.value)
         ) {
             return;
@@ -88,7 +90,7 @@ export default function WaypointForm({ editState, clearEditState }: WaypointForm
     };
 
     const handleFormSubmit = () => {
-        if (checkReqFields(["lat", "long", "alt"])) {
+        if (checkReqFields(["latitude", "longitude", "alt"])) {
             const waypoint = parseWaypointForm(formState);
             dispatch(addToQueuedWaypoints(waypoint));
         }
@@ -119,28 +121,28 @@ export default function WaypointForm({ editState, clearEditState }: WaypointForm
                 <TextField
                     fullWidth
                     required
-                    id="lat"
+                    id="latitude"
                     type="string"
                     label="Latitude"
                     onChange={handleFormChange}
                     onWheel={preventScroll}
-                    value={formState.lat}
-                    error={formErrors.lat}
-                    helperText={formErrors.lat && "Latitude is required."}
+                    value={formState.latitude}
+                    error={formErrors.latitude}
+                    helperText={formErrors.latitude && "Latitude is required."}
                 />
             </Grid>
             <Grid item xs={12} lg={6}>
                 <TextField
                     fullWidth
                     required
-                    id="long"
+                    id="longitude"
                     type="string"
                     label="Longitude"
                     onChange={handleFormChange}
                     onWheel={preventScroll}
-                    value={formState.long}
-                    error={formErrors.long}
-                    helperText={formErrors.long && "Longitude is required."}
+                    value={formState.longitude}
+                    error={formErrors.longitude}
+                    helperText={formErrors.longitude && "Longitude is required."}
                 />
             </Grid>
             <Grid item xs={12} lg={6}>

--- a/projects/web-frontend/src/routes/Settings.tsx
+++ b/projects/web-frontend/src/routes/Settings.tsx
@@ -18,13 +18,13 @@ export default function Settings() {
     const settings = useAppSelector(selectAppSlice);
 
     const [coords, setCoords] = useState<StringCoords>({
-        lat: settings.mapCenterCoords.lat.toString(),
-        long: settings.mapCenterCoords.long.toString(),
+        latitude: settings.mapCenterCoords.latitude.toString(),
+        longitude: settings.mapCenterCoords.longitude.toString(),
     });
 
     const getCoordError = (coords: StringCoords) => ({
-        lat: !checkLat(parseFloat(coords.lat)),
-        long: !checkLong(parseFloat(coords.long)),
+        latitude: !checkLat(parseFloat(coords.latitude)),
+        longitude: !checkLong(parseFloat(coords.longitude)),
     });
 
     const handleThemeChange = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -47,11 +47,11 @@ export default function Settings() {
         // allow changes to input even if its not a valid coordinate
         const newCoords =
             event.target.id === "longitude"
-                ? { ...coords, long: event.target.value }
-                : { ...coords, lat: event.target.value };
+                ? { ...coords, longitude: event.target.value }
+                : { ...coords, latitude: event.target.value };
         setCoords(newCoords);
         // ONLY update store coords if the input is a valid coordinate.
-        const parsedCoords = { lat: parseFloat(newCoords.lat), long: parseFloat(newCoords.long) };
+        const parsedCoords = { latitude: parseFloat(newCoords.latitude), longitude: parseFloat(newCoords.longitude) };
         if (validCoords(parsedCoords)) {
             dispatch(setMapCenterCoords(parsedCoords));
         }
@@ -111,17 +111,17 @@ export default function Settings() {
                         id="longitude"
                         type="text"
                         name="Map Default Center Longitude"
-                        value={coords.long}
+                        value={coords.longitude}
                         onChange={handleDefaultCoordChange}
-                        error={getCoordError(coords).long}
+                        error={getCoordError(coords).longitude}
                     />
                     <SettingItem
                         id="latitude"
                         type="text"
                         name="Map Default Center Latitude"
-                        value={coords.lat}
+                        value={coords.latitude}
                         onChange={handleDefaultCoordChange}
-                        error={getCoordError(coords).lat}
+                        error={getCoordError(coords).latitude}
                     />
                 </Stack>
             </Paper>

--- a/projects/web-frontend/src/store/slices/dataSlice.ts
+++ b/projects/web-frontend/src/store/slices/dataSlice.ts
@@ -24,8 +24,8 @@ const initialState: DataState = {
     route: {
         id: 0,
         waypoints: [
-            { id: "0", name: "a", lat: 10, long: 10 },
-            { id: "1", name: "b", lat: -10, long: -10 },
+            { id: "0", name: "a", latitude: 10, longitude: 10 },
+            { id: "1", name: "b", latitude: -10, longitude: -10 },
         ],
     },
 };

--- a/projects/web-frontend/src/types/Coords.ts
+++ b/projects/web-frontend/src/types/Coords.ts
@@ -1,9 +1,9 @@
 export type Coords = {
-    lat: number;
-    long: number;
+    latitude: number;
+    longitude: number;
 };
 
 export type StringCoords = {
-    lat: string;
-    long: string;
+    latitude: string;
+    longitude: string;
 };

--- a/projects/web-frontend/src/types/Waypoint.ts
+++ b/projects/web-frontend/src/types/Waypoint.ts
@@ -13,8 +13,8 @@ export enum Designation {
 export type Waypoint = {
     id: string;
     name?: string;
-    lat: number;
-    long: number;
+    latitude: number;
+    longitude: number;
     alt?: number;
     radius?: number;
     remarks?: string;

--- a/projects/web-frontend/src/types/WaypointForm.ts
+++ b/projects/web-frontend/src/types/WaypointForm.ts
@@ -3,8 +3,8 @@ import { Waypoint } from "./Waypoint";
 export type FormState = Record<keyof Omit<Waypoint, "id">, string>;
 
 export type FormErrors = {
-    lat: boolean;
-    long: boolean;
+    latitude: boolean;
+    longitude: boolean;
     alt: boolean;
 };
 

--- a/projects/web-frontend/src/utils/coords.ts
+++ b/projects/web-frontend/src/utils/coords.ts
@@ -2,12 +2,17 @@ import { Coords } from "../types/Coords";
 
 export const defaultCoords: Coords = {
     // UBC
-    long: -123.246,
-    lat: 49.2606,
+    longitude: -123.246,
+    latitude: 49.2606,
 };
 
 export function validCoords(coords: Coords) {
-    return coords.lat !== null && coords.long !== null && checkLat(coords.lat) && checkLong(coords.long);
+    return (
+        coords.latitude !== null &&
+        coords.longitude !== null &&
+        checkLat(coords.latitude) &&
+        checkLong(coords.longitude)
+    );
 }
 
 export function checkLat(lat: number) {

--- a/projects/web-frontend/src/utils/parseWaypointForm.ts
+++ b/projects/web-frontend/src/utils/parseWaypointForm.ts
@@ -8,8 +8,8 @@ const parseOptionalFloat = (field: string) => {
 
 export default function parseWaypointForm(formState: FormState): Waypoint {
     return {
-        lat: parseFloat(formState.lat),
-        long: parseFloat(formState.long),
+        latitude: parseFloat(formState.latitude),
+        longitude: parseFloat(formState.longitude),
         alt: parseOptionalFloat(formState.alt),
         radius: parseOptionalFloat(formState.radius),
         name: formState.name.trim(),


### PR DESCRIPTION
# Description

Standardizes frontend coordinate field names to match backend API contracts. The frontend was using abbreviated field names (`lat`/`long`) while the mission-planner API spec and web-backend database models expect full field names (`latitude`/`longitude`).

This caused endpoint parity issues since web-backend acts as a pass-through proxy that forwards waypoint data to mission-planner without field transformation. The mission-planner httpserver.py explicitly accesses `wpdict["latitude"]` and `wpdict["longitude"]` when processing waypoint data.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

# Changes Made

**Type Definitions:**
- `types/Waypoint.ts`: Changed `lat`/`long` to `latitude`/`longitude`
- `types/Coords.ts`: Updated Coords and StringCoords types
- `types/WaypointForm.ts`: Updated FormErrors fields

**Utilities:**
- `utils/parseWaypointForm.ts`: Updated field mappings
- `utils/coords.ts`: Updated defaultCoords and validCoords

**Store:**
- `store/slices/dataSlice.ts`: Updated initial waypoints data

**Components:**
- `routes/Settings.tsx`: Updated coordinate state and handlers
- `components/WaypointStatus/WaypointForm.tsx`: Updated form state, errors, and TextField IDs
- `components/Map/WaypointCreationMap.tsx`: Updated all waypoint references and DraggedMarker type
- `components/Map/MapView.tsx`: Updated all waypoint references
- `components/WaypointItem.tsx`: Updated display fields

# How Has This Been Tested?

- [x] Validated mission-planner expects `latitude`/`longitude` (checked httpserver.py implementation)
- [x] Verified web-backend forwards JSON without transformation (checked DroneApiClient)
- [x] Confirmed database models use `latitude`/`longitude` (OrderedWaypoint model)
- [x] Checked integration test fixtures already use `latitude`/`longitude`
- [x] Verified no remaining `lat`/`long` references in types or component logic

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional Notes

**Action Items for Testing:**
1. Test the `/api/route` endpoint to ensure OrderedWaypoint serialization works correctly
2. Check for any persisted frontend state (localStorage/sessionStorage) that might contain waypoints with old field names
3. Run integration tests to verify end-to-end functionality

**Related Issues:**
- Fixes endpoint parity issue between frontend and mission-planner API
- Aligns frontend with backend naming conventions used across the stack