### PR TITLE
Add RTL altitude input and button to Drone status card

### DIFF
--- a/projects/integration-tests/helpers/__init__.py
+++ b/projects/integration-tests/helpers/__init__.py
@@ -7,6 +7,9 @@ from .waiters import (
     wait_for_waypoint_count,
     wait_for_drone_armed,
     wait_for_status_field,
+    wait_for_flight_mode,
+    wait_for_position,
+    wait_for_stationary,
 )
 from .assertions import (
     assert_waypoint_match,
@@ -35,6 +38,9 @@ __all__ = [
     "wait_for_waypoint_count",
     "wait_for_drone_armed",
     "wait_for_status_field",
+    "wait_for_flight_mode",
+    "wait_for_position",
+    "wait_for_stationary",
     "assert_waypoint_match",
     "assert_waypoints_match",
     "assert_status_valid",

--- a/projects/integration-tests/helpers/api_client.py
+++ b/projects/integration-tests/helpers/api_client.py
@@ -152,6 +152,25 @@ class APIClient:
             response = requests.get(f"{self.web_backend_url}/api/drone/rtl")
         return response
 
+    def prepare_rtl_params(self, altitude: float) -> Response:
+        """Prepare RTL parameters via web-backend.
+
+        Sets RTL altitude parameter without triggering RTL mode.
+        The drone will not switch to RTL mode until explicitly commanded.
+
+        Args:
+            altitude: RTL altitude in meters
+
+        Returns:
+            Response object
+        """
+        response = requests.post(
+            f"{self.web_backend_url}/api/drone/prepare_rtl",
+            json={"altitude": altitude},
+            headers={"Content-Type": "application/json"},
+        )
+        return response
+
     def post_home(self, waypoint: Dict[str, Any]) -> Response:
         """Set home position via web-backend.
 
@@ -180,6 +199,32 @@ class APIClient:
         response = requests.post(
             f"{self.web_backend_url}/api/drone/insert",
             json=waypoints,
+            headers={"Content-Type": "application/json"},
+        )
+        return response
+
+    def get_flight_mode(self) -> str:
+        """Get current flight mode via web-backend.
+
+        Returns:
+            Flight mode string (e.g., "GUIDED", "AUTO", "LOITER")
+        """
+        response = requests.get(f"{self.web_backend_url}/api/drone/flightmode")
+        response.raise_for_status()
+        return response.json()["mode"]
+
+    def set_flight_mode(self, mode: str) -> Response:
+        """Set flight mode via web-backend.
+
+        Args:
+            mode: Flight mode string (e.g., "GUIDED", "AUTO", "LOITER", "RTL")
+
+        Returns:
+            Response object
+        """
+        response = requests.put(
+            f"{self.web_backend_url}/api/drone/flightmode",
+            json={"mode": mode},
             headers={"Content-Type": "application/json"},
         )
         return response

--- a/projects/integration-tests/helpers/api_client.py
+++ b/projects/integration-tests/helpers/api_client.py
@@ -165,7 +165,7 @@ class APIClient:
             Response object
         """
         response = requests.post(
-            f"{self.web_backend_url}/api/drone/prepare_rtl",
+            f"{self.web_backend_url}/api/drone/prepare_rtl_params",
             json={"altitude": altitude},
             headers={"Content-Type": "application/json"},
         )
@@ -289,7 +289,9 @@ class APIClient:
         )
         return response
 
-    def partial_update_waypoint(self, waypoint_id: str, data: Dict[str, Any]) -> Response:
+    def partial_update_waypoint(
+        self, waypoint_id: str, data: Dict[str, Any]
+    ) -> Response:
         """Partially update a waypoint in the database.
 
         Args:
@@ -315,7 +317,9 @@ class APIClient:
         Returns:
             Response object
         """
-        response = requests.delete(f"{self.web_backend_url}/api/waypoint/{waypoint_id}/")
+        response = requests.delete(
+            f"{self.web_backend_url}/api/waypoint/{waypoint_id}/"
+        )
         return response
 
     # ==================== Database Route API Methods ====================
@@ -371,7 +375,9 @@ class APIClient:
         response = requests.delete(f"{self.web_backend_url}/api/route/{route_id}/")
         return response
 
-    def reorder_route_waypoints(self, route_id: int, waypoint_ids: List[str]) -> Response:
+    def reorder_route_waypoints(
+        self, route_id: int, waypoint_ids: List[str]
+    ) -> Response:
         """Reorder waypoints within a route.
 
         Args:

--- a/projects/integration-tests/helpers/waiters.py
+++ b/projects/integration-tests/helpers/waiters.py
@@ -171,3 +171,154 @@ def wait_for_status_field(
         poll_interval=1.0,
         error_message=f"Status field '{field_name}' did not reach value {expected_value}",
     )
+
+
+def wait_for_flight_mode(
+    api_client: APIClient, mode: str, timeout: float = 30.0
+) -> None:
+    """Wait for drone to enter specified flight mode.
+
+    Args:
+        api_client: API client instance
+        mode: Expected flight mode (e.g., "GUIDED", "AUTO", "LOITER")
+        timeout: Maximum time to wait in seconds
+
+    Raises:
+        TimeoutError: If mode not reached within timeout
+    """
+
+    def check_mode() -> bool:
+        try:
+            current_mode = api_client.get_flight_mode()
+            print(f"Current flight mode: {current_mode}, Target: {mode}")
+            return current_mode == mode
+        except:
+            return False
+
+    wait_for_condition(
+        check_mode,
+        timeout=timeout,
+        poll_interval=1.0,
+        error_message=f"Drone did not enter {mode} mode",
+    )
+
+
+def wait_for_position(
+    api_client: APIClient,
+    target_lat: float,
+    target_lon: float,
+    timeout: float = 60.0,
+    tolerance_meters: float = 10.0,
+) -> None:
+    """Wait for drone to reach target position.
+
+    Args:
+        api_client: API client instance
+        target_lat: Target latitude
+        target_lon: Target longitude
+        timeout: Maximum time to wait in seconds
+        tolerance_meters: Acceptable distance from target in meters
+
+    Raises:
+        TimeoutError: If position not reached within timeout
+    """
+
+    def check_position() -> bool:
+        try:
+            status = api_client.get_status()
+            current_lat = status.get("latitude")
+            current_lon = status.get("longitude")
+
+            if current_lat is None or current_lon is None:
+                return False
+
+            # Rough conversion: 1 degree lat/lon ≈ 111km at equator
+            lat_diff_m = abs(current_lat - target_lat) * 111000
+            lon_diff_m = abs(current_lon - target_lon) * 111000
+            distance = (lat_diff_m**2 + lon_diff_m**2) ** 0.5
+
+            print(
+                f"Current position: ({current_lat:.6f}, {current_lon:.6f}), "
+                f"Target: ({target_lat:.6f}, {target_lon:.6f}), "
+                f"Distance: {distance:.1f}m"
+            )
+
+            return distance <= tolerance_meters
+        except:
+            return False
+
+    wait_for_condition(
+        check_position,
+        timeout=timeout,
+        poll_interval=2.0,
+        error_message=f"Drone did not reach position ({target_lat}, {target_lon}) within {tolerance_meters}m",
+    )
+
+
+def wait_for_stationary(
+    api_client: APIClient,
+    duration: float = 10.0,
+    speed_threshold: float = 0.5,
+    vertical_speed_threshold: float = 0.5,
+    timeout: float = 60.0,
+) -> None:
+    """Wait for drone to be stationary (hovering).
+
+    Verifies drone maintains low speed for specified duration.
+
+    Args:
+        api_client: API client instance
+        duration: How long drone must remain stationary in seconds
+        speed_threshold: Maximum groundspeed in m/s to be considered stationary
+        vertical_speed_threshold: Maximum vertical speed in m/s
+        timeout: Maximum time to wait in seconds
+
+    Raises:
+        TimeoutError: If drone doesn't become stationary within timeout
+    """
+    stationary_start = None
+
+    def check_stationary() -> bool:
+        nonlocal stationary_start
+        try:
+            status = api_client.get_status()
+            groundspeed = status.get("groundspeed", float("inf"))
+            verticalspeed = abs(status.get("verticalspeed", float("inf")))
+
+            is_stationary = (
+                groundspeed < speed_threshold
+                and verticalspeed < vertical_speed_threshold
+            )
+
+            if is_stationary:
+                if stationary_start is None:
+                    stationary_start = time.time()
+                    print(f"Drone stationary, monitoring for {duration}s...")
+
+                elapsed = time.time() - stationary_start
+                print(
+                    f"Stationary for {elapsed:.1f}s (groundspeed: {groundspeed:.2f} m/s, "
+                    f"verticalspeed: {verticalspeed:.2f} m/s)"
+                )
+
+                if elapsed >= duration:
+                    return True
+            else:
+                if stationary_start is not None:
+                    print(
+                        f"Drone moving (groundspeed: {groundspeed:.2f} m/s, "
+                        f"verticalspeed: {verticalspeed:.2f} m/s), resetting timer..."
+                    )
+                stationary_start = None
+
+            return False
+        except:
+            stationary_start = None
+            return False
+
+    wait_for_condition(
+        check_stationary,
+        timeout=timeout,
+        poll_interval=1.0,
+        error_message=f"Drone did not remain stationary for {duration}s",
+    )

--- a/projects/integration-tests/tests/test_autonomous_navigation.py
+++ b/projects/integration-tests/tests/test_autonomous_navigation.py
@@ -1,0 +1,285 @@
+"""Integration test for autonomous navigation with waypoint missions.
+
+This test verifies complex flight sequences including waypoint navigation,
+mid-flight mode changes, and air-start scenarios.
+"""
+
+import pytest
+from helpers import (
+    wait_for_altitude,
+    wait_for_flight_mode,
+    wait_for_position,
+    wait_for_stationary,
+    filter_home_waypoint,
+)
+
+
+@pytest.mark.slow
+@pytest.mark.critical
+def test_autonomous_navigation(api_client, flight_cleanup):
+    """Test autonomous waypoint navigation with air start.
+
+    This test validates:
+    - Takeoff and altitude achievement
+    - Mid-flight mode switching (AUTO -> GUIDED -> AUTO)
+    - Air start waypoint navigation
+    - Waypoint mission execution (3 waypoints + return home + loiter)
+    - RTL parameter preparation without mode change
+    - Manual RTL initiation and landing
+
+    Test Sequence:
+    PHASE 1: Initial Takeoff
+    1. Prepare takeoff to altitude 50m
+    2. Arm drone
+    3. Switch to AUTO mode
+    4. Verify altitude reached
+    5. Switch to GUIDED mode (mid-flight)
+
+    PHASE 2: Mission Setup
+    6. Upload waypoint mission:
+       - 3 navigation waypoints
+       - Return to start position
+       - Loiter indefinitely
+    7. Switch to AUTO mode (air start)
+
+    PHASE 3: Mission Execution
+    8. Verify drone navigates to each waypoint
+    9. Verify drone returns to start
+    10. Verify drone loiters at final waypoint
+
+    PHASE 4: Landing
+    11. Prepare RTL parameters (verify no mode change)
+    12. Trigger RTL mode manually
+    13. Verify drone returns home and lands
+
+    Expected Timeline:
+    - Takeoff: ~20 seconds
+    - Waypoint navigation: ~2-3 minutes
+    - Loiter verification: ~30 seconds
+    - RTL and landing: ~30 seconds
+    - Total: ~4-5 minutes
+
+    Cleanup:
+    - Automatic cleanup via flight_cleanup fixture
+
+    Args:
+        api_client: API client fixture
+        flight_cleanup: Flight cleanup fixture
+    """
+    # Configuration
+    takeoff_altitude = 50.0
+    rtl_altitude = 30.0
+
+    # PHASE 1: Initial Takeoff
+    print("\n=== PHASE 1: Initial Takeoff ===")
+
+    # Get baseline altitude
+    initial_status = api_client.get_status()
+    baseline_altitude = initial_status["altitude"]
+    start_lat = initial_status["latitude"]
+    start_lon = initial_status["longitude"]
+    target_altitude = baseline_altitude + takeoff_altitude
+
+    print(f"Start position: ({start_lat:.6f}, {start_lon:.6f})")
+    print(f"Baseline altitude: {baseline_altitude}m")
+    print(f"Target altitude: {target_altitude}m")
+
+    # Prepare takeoff
+    response = api_client.prepare_takeoff(target_altitude)
+    assert response.status_code == 200, f"Prepare takeoff failed: {response.text}"
+    print(f"Prepare takeoff command sent (altitude: {target_altitude}m)")
+
+    # Arm drone
+    response = api_client.arm(True)
+    assert response.status_code == 200, f"Arm command failed: {response.text}"
+    print("Drone armed")
+
+    # Switch to AUTO mode to initiate takeoff
+    response = api_client.set_flight_mode_direct("AUTO")
+    assert response.status_code == 200, f"AUTO mode failed: {response.text}"
+    print("Switched to AUTO mode - initiating takeoff")
+
+    # Wait for target altitude
+    wait_for_altitude(api_client, target_altitude, timeout=120, tolerance=2.0)
+    print(f"Takeoff complete - altitude: {target_altitude}m")
+
+    # Switch to GUIDED mode (mid-flight mode change)
+    print("Switching to GUIDED mode (mid-flight)...")
+    response = api_client.set_flight_mode_direct("GUIDED")
+    assert response.status_code == 200, f"GUIDED mode failed: {response.text}"
+
+    wait_for_flight_mode(api_client, "GUIDED", timeout=10)
+    print("GUIDED mode active")
+
+    # PHASE 2: Mission Setup
+    print("\n=== PHASE 2: Mission Setup ===")
+
+    # Create waypoint mission
+    # Using offsets to create a simple box pattern around start position
+    lat_offset = 0.0001  # ~11 meters
+    lon_offset = 0.0001  # ~11 meters
+
+    waypoints = [
+        # WP1: North
+        {
+            "id": 1,
+            "name": "WP1 North",
+            "latitude": start_lat + lat_offset,
+            "longitude": start_lon,
+            "altitude": target_altitude,
+        },
+        # WP2: North-East
+        {
+            "id": 2,
+            "name": "WP2 North-East",
+            "latitude": start_lat + lat_offset,
+            "longitude": start_lon + lon_offset,
+            "altitude": target_altitude,
+        },
+        # WP3: East
+        {
+            "id": 3,
+            "name": "WP3 East",
+            "latitude": start_lat,
+            "longitude": start_lon + lon_offset,
+            "altitude": target_altitude,
+        },
+        # WP4: Return to start
+        {
+            "id": 4,
+            "name": "WP4 Return",
+            "latitude": start_lat,
+            "longitude": start_lon,
+            "altitude": target_altitude,
+        },
+        # WP5: Loiter indefinitely at start position
+        {
+            "id": 5,
+            "name": "WP5 Loiter",
+            "latitude": start_lat,
+            "longitude": start_lon,
+            "altitude": target_altitude,
+            "command": "LOITER_UNLIM",
+        },
+    ]
+
+    print(f"Uploading mission with {len(waypoints)} waypoints...")
+    response = api_client.post_queue(waypoints)
+    assert response.status_code == 200, f"Failed to upload waypoints: {response.text}"
+
+    # Verify queue
+    queue = api_client.get_queue()
+    filtered_queue = filter_home_waypoint(queue)
+    assert len(filtered_queue) == len(waypoints), (
+        f"Expected {len(waypoints)} waypoints in queue, got {len(filtered_queue)}"
+    )
+    print(f"Mission uploaded: {len(filtered_queue)} waypoints")
+
+    # PHASE 3: Mission Execution (Air Start)
+    print("\n=== PHASE 3: Mission Execution (Air Start) ===")
+
+    # Switch to AUTO mode while airborne (air start)
+    print("Switching to AUTO mode (air start)...")
+    response = api_client.set_flight_mode_direct("AUTO")
+    assert response.status_code == 200, f"AUTO mode failed: {response.text}"
+
+    wait_for_flight_mode(api_client, "AUTO", timeout=10)
+    print("AUTO mode active - drone should proceed to first waypoint")
+
+    # Navigate through waypoints
+    print("\nNavigating to waypoints...")
+
+    for i, wp in enumerate(waypoints[:-1], start=1):  # Exclude loiter waypoint
+        print(f"Waypoint {i}/{len(waypoints)-1}: ({wp['latitude']:.6f}, {wp['longitude']:.6f})")
+        wait_for_position(
+            api_client,
+            wp["latitude"],
+            wp["longitude"],
+            timeout=120,
+            tolerance_meters=15.0,
+        )
+        print(f"Reached waypoint {i}")
+
+    # Verify loiter at final waypoint
+    print("\nVerifying loiter at final waypoint...")
+    final_wp = waypoints[-1]
+    wait_for_position(
+        api_client,
+        final_wp["latitude"],
+        final_wp["longitude"],
+        timeout=120,
+        tolerance_meters=15.0,
+    )
+    print("Reached final waypoint (loiter position)")
+
+    # Verify drone is hovering/loitering
+    print("Verifying loiter behavior (stationary for 20s)...")
+    wait_for_stationary(
+        api_client,
+        duration=20.0,
+        speed_threshold=1.0,
+        vertical_speed_threshold=0.5,
+        timeout=60.0,
+    )
+    print("Loiter confirmed - drone hovering at final waypoint")
+
+    # PHASE 4: Landing
+    print("\n=== PHASE 4: Landing ===")
+
+    # Prepare RTL parameters
+    print(f"Preparing RTL parameters (altitude: {rtl_altitude}m)...")
+    current_mode_before = api_client.get_flight_mode()
+    response = api_client.prepare_rtl_params(rtl_altitude)
+    assert response.status_code == 200, f"Prepare RTL params failed: {response.text}"
+    print("RTL parameters set")
+
+    # Verify mode did NOT change
+    current_mode_after = api_client.get_flight_mode()
+    assert current_mode_after == current_mode_before, (
+        f"Flight mode should not change after prepare_rtl_params. "
+        f"Expected: {current_mode_before}, Got: {current_mode_after}"
+    )
+    print(f"Flight mode unchanged: {current_mode_after}")
+
+    # Trigger RTL manually
+    print("Triggering RTL mode manually...")
+    response = api_client.set_flight_mode_direct("RTL")
+    assert response.status_code == 200, f"RTL mode failed: {response.text}"
+
+    wait_for_flight_mode(api_client, "RTL", timeout=10)
+    print("RTL mode active - drone returning home")
+
+    # Wait for drone to return to baseline altitude (landed)
+    print(f"Waiting for landing (baseline altitude: {baseline_altitude}m)...")
+    wait_for_altitude(
+        api_client,
+        baseline_altitude,
+        timeout=180,
+        tolerance=2.0,
+    )
+    print("Drone landed")
+
+    # Verify final position near start
+    final_status = api_client.get_status()
+    final_lat = final_status["latitude"]
+    final_lon = final_status["longitude"]
+
+    # Calculate distance from start
+    lat_diff_m = abs(final_lat - start_lat) * 111000
+    lon_diff_m = abs(final_lon - start_lon) * 111000
+    distance_from_start = (lat_diff_m**2 + lon_diff_m**2) ** 0.5
+
+    print(
+        f"Final position: ({final_lat:.6f}, {final_lon:.6f}), "
+        f"Distance from start: {distance_from_start:.1f}m"
+    )
+
+    assert distance_from_start <= 20.0, (
+        f"Drone should land near start position, but is {distance_from_start:.1f}m away"
+    )
+
+    print("\n=== Test Complete ===")
+    print(f"Mission executed successfully:")
+    print(f"  - Navigated {len(waypoints)} waypoints")
+    print(f"  - Loitered at final position")
+    print(f"  - Returned home and landed")

--- a/projects/integration-tests/tests/test_basic_takeoff_and_hover.py
+++ b/projects/integration-tests/tests/test_basic_takeoff_and_hover.py
@@ -1,0 +1,153 @@
+"""Integration test for basic takeoff and hover sequence.
+
+This test verifies that prepare_takeoff clears existing waypoints and the drone
+can takeoff and maintain a stable hover at the target altitude.
+"""
+
+import pytest
+from helpers import (
+    wait_for_altitude,
+    wait_for_flight_mode,
+    wait_for_stationary,
+    filter_home_waypoint,
+)
+
+
+@pytest.mark.slow
+@pytest.mark.critical
+def test_basic_takeoff_and_hover(api_client, flight_cleanup):
+    """Test basic takeoff and hover sequence.
+
+    This test validates:
+    - Prepare takeoff clears existing waypoints
+    - Prepare takeoff does not change flight mode
+    - Operator can arm and set GUIDED mode manually
+    - Switching to AUTO initiates takeoff
+    - Drone reaches target altitude and hovers stably
+
+    Test Sequence:
+    1. Add a test waypoint to mission queue
+    2. Send prepare_takeoff command (altitude 40m)
+       - Verify queue cleared (only home + takeoff waypoint)
+       - Verify flight mode unchanged
+    3. Arm drone and switch to GUIDED mode (emulating pilot)
+       - Verify GUIDED mode active
+    4. Switch to AUTO mode (emulating pilot)
+       - Drone should takeoff to 40m
+    5. Verify drone maintains stable hover
+
+    Expected Timeline:
+    - Arming + Takeoff to 40m: ~15-20 seconds
+    - Hover verification: ~10 seconds
+    - Total test duration: ~30-45 seconds
+
+    Cleanup:
+    - Automatic cleanup via flight_cleanup fixture
+
+    Args:
+        api_client: API client fixture
+        flight_cleanup: Flight cleanup fixture
+    """
+    target_relative_altitude = 40.0
+
+    # Step 1: Get initial status and baseline altitude
+    initial_status = api_client.get_status()
+    baseline_altitude = initial_status["altitude"]
+    target_altitude = baseline_altitude + target_relative_altitude
+    initial_mode = api_client.get_flight_mode()
+
+    print(f"Initial altitude: {baseline_altitude}m, Initial mode: {initial_mode}")
+    print(f"Target altitude: {target_altitude}m ({target_relative_altitude}m relative)")
+
+    # Step 2: Add a dummy waypoint to test that prepare_takeoff clears it
+    dummy_waypoint = [
+        {
+            "id": 1,
+            "name": "Dummy Waypoint",
+            "latitude": -35.363261,
+            "longitude": 149.165230,
+            "altitude": 100.0,
+        }
+    ]
+    response = api_client.post_queue(dummy_waypoint)
+    assert response.status_code == 200, f"Failed to add dummy waypoint: {response.text}"
+    print("Dummy waypoint added to queue")
+
+    # Verify dummy waypoint exists
+    queue = api_client.get_queue()
+    filtered_queue = filter_home_waypoint(queue)
+    assert len(filtered_queue) == 1, "Dummy waypoint should be in queue"
+
+    # Step 3: Prepare takeoff (should clear dummy waypoint and add takeoff waypoint)
+    response = api_client.prepare_takeoff(target_altitude)
+    assert response.status_code == 200, f"Prepare takeoff failed: {response.text}"
+    print(f"Prepare takeoff command sent (altitude: {target_altitude}m)")
+
+    # Step 4: Verify queue cleared and only contains home + takeoff waypoint
+    queue = api_client.get_queue()
+    filtered_queue = filter_home_waypoint(queue)
+    assert len(filtered_queue) == 1, (
+        f"Queue should only contain 1 waypoint (takeoff), found {len(filtered_queue)}"
+    )
+    print("Queue verified: dummy waypoint cleared, only takeoff waypoint present")
+
+    # Step 5: Verify flight mode did NOT change
+    current_mode = api_client.get_flight_mode()
+    assert current_mode == initial_mode, (
+        f"Flight mode should not change after prepare_takeoff. "
+        f"Expected: {initial_mode}, Got: {current_mode}"
+    )
+    print(f"Flight mode unchanged: {current_mode}")
+
+    # Step 6: Arm the drone (emulating pilot action)
+    response = api_client.arm(True)
+    assert response.status_code == 200, f"Arm command failed: {response.text}"
+    print("Drone armed")
+
+    # Step 7: Set to GUIDED mode (emulating pilot action via mission-planner)
+    response = api_client.set_flight_mode_direct("GUIDED")
+    assert response.status_code == 200, f"GUIDED mode command failed: {response.text}"
+    print("Switched to GUIDED mode via mission-planner")
+
+    # Wait and verify GUIDED mode is active
+    wait_for_flight_mode(api_client, "GUIDED", timeout=10)
+    print("GUIDED mode confirmed")
+
+    # Step 8: Switch to AUTO mode (emulating pilot action)
+    response = api_client.set_flight_mode_direct("AUTO")
+    assert response.status_code == 200, f"AUTO mode command failed: {response.text}"
+    print("Switched to AUTO mode - drone should now takeoff")
+
+    # Step 9: Wait for drone to reach target altitude
+    wait_for_altitude(
+        api_client,
+        target_altitude,
+        timeout=120,
+        tolerance=2.0,
+    )
+    print(f"Drone reached target altitude: {target_altitude}m")
+
+    # Step 10: Verify altitude is correct
+    status = api_client.get_status()
+    assert abs(status["altitude"] - target_altitude) <= 2.0, (
+        f"Altitude mismatch: {status['altitude']}m != {target_altitude}m"
+    )
+
+    # Step 11: Verify drone is hovering (stationary for 10 seconds)
+    print("Verifying stable hover...")
+    wait_for_stationary(
+        api_client,
+        duration=10.0,
+        speed_threshold=0.5,
+        vertical_speed_threshold=0.5,
+        timeout=60.0,
+    )
+    print("Drone hovering stably at target altitude")
+
+    # Final verification
+    final_status = api_client.get_status()
+    print(
+        f"Final state - Altitude: {final_status['altitude']:.1f}m, "
+        f"Groundspeed: {final_status['groundspeed']:.2f} m/s, "
+        f"Vertical speed: {final_status['verticalspeed']:.2f} m/s"
+    )

--- a/projects/mission-planner/src/server/httpserver.py
+++ b/projects/mission-planner/src/server/httpserver.py
@@ -261,6 +261,24 @@ class HTTP_Server:
             else:
                 return f"Unrecognized arm/disarm command parameter", 400
 
+        @app.route("/prepare_rtl_params", methods=["POST"])
+        def post_prepare_rtl_params():
+            payload = request.get_json()
+
+            if not ("altitude" in payload):
+                return "Altitude cannot be null", 400
+
+            altitude = payload["altitude"]
+            print(f"Preparing RTL params with altitude {altitude}")
+
+            # set RTL altitude parameter
+            alt_cm = altitude * 100
+
+            if not set_parameter(self.handler, "RTL_ALT", alt_cm):
+                return "Failed to set RTL altitude parameter", 400
+
+            return "RTL parameters prepared successfully", 200
+
         @app.route("/rtl", methods=["GET", "POST"])
         def get_post_rtl():
             if request.method == "GET":

--- a/projects/web-backend/src/drone/mps_api.py
+++ b/projects/web-backend/src/drone/mps_api.py
@@ -48,6 +48,12 @@ class DroneApiClient:
         )
 
     @staticmethod
+    def prepare_rtl_params(altitude):
+        return DroneApiClient._fetch_from_mission_planner(
+            "prepare_rtl_params", method="POST", data={"altitude": altitude}
+        )
+
+    @staticmethod
     def arm(arm_value):
         return DroneApiClient._fetch_from_mission_planner(
             "arm", method="PUT", data={"arm": arm_value}

--- a/projects/web-backend/src/drone/urls.py
+++ b/projects/web-backend/src/drone/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     path("status/history", views.get_status_history, name="get_status_history"),
     path("takeoff", views.takeoff, name="takeoff"),
     path("prepare_takeoff", views.prepare_takeoff, name="prepare_takeoff"),
+    path("prepare_rtl_params", views.prepare_rtl_params, name="prepare_rtl_params"),
     path("arm", views.arm, name="arm"),
     path("land", views.land, name="land"),
     path("rtl", views.get_rtl, name="rtl"),

--- a/projects/web-backend/src/drone/views.py
+++ b/projects/web-backend/src/drone/views.py
@@ -72,6 +72,33 @@ def prepare_takeoff(request):
 
 
 @csrf_exempt
+@require_http_methods(["POST"])
+def prepare_rtl_params(request):
+    try:
+        data = json.loads(request.body)
+        altitude = data.get("altitude")
+        response = DroneApiClient.prepare_rtl_params(altitude)
+
+        if response.status_code >= 400:
+            print(f"[ERROR] Mission-planner response: {response.text}")
+            return JsonResponse(
+                {"error": "Mission-planner error", "details": response.text},
+                status=response.status_code,
+            )
+
+        return HttpResponse(status=response.status_code)
+    except (KeyError, ValueError, TypeError) as e:
+        print(f"[ERROR] Invalid input for prepare_rtl_params: {type(e).__name__}: {str(e)}")
+        return JsonResponse({"error": "Invalid input"}, status=400)
+    except Exception as e:
+        print(f"[ERROR] Unexpected error in prepare_rtl_params: {type(e).__name__}: {str(e)}")
+        return JsonResponse(
+            {"error": "Internal server error", "details": str(e)},
+            status=500,
+        )
+
+
+@csrf_exempt
 @require_http_methods(["PUT"])
 def arm(request):
     try:

--- a/projects/web-frontend/src/api/endpoints.ts
+++ b/projects/web-frontend/src/api/endpoints.ts
@@ -17,6 +17,10 @@ export const prepareTakeoffDrone = async (altitude: number) => {
     return await api.post("/drone/prepare_takeoff", { altitude });
 };
 
+export const prepareRtlParams = async (altitude: number) => {
+    return await api.post("/drone/prepare_rtl_params", { altitude });
+};
+
 export const postWaypointsToDrone = async (waypoints: Waypoint[]) => {
     console.log("Preparing to post waypoints to drone via API", waypoints);
     return await api.post("/drone/queue", waypoints);

--- a/projects/web-frontend/src/components/DroneStatus/MPSControlSection.tsx
+++ b/projects/web-frontend/src/components/DroneStatus/MPSControlSection.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Modal, Paper, TextField, Tooltip, Typography } from "@mui/material";
 import InfoIcon from "@mui/icons-material/Info";
 import { useState } from "react";
-import { armDrone, prepareTakeoffDrone } from "../../api/endpoints.ts";
+import { armDrone, prepareTakeoffDrone, prepareRtlParams } from "../../api/endpoints.ts";
 import { openSnackbar } from "../../store/slices/appSlice";
 import { selectAircraftStatus } from "../../store/slices/dataSlice";
 import { useAppDispatch, useAppSelector } from "../../store/store";
@@ -10,8 +10,10 @@ export default function MPSControlSection() {
     const dispatch = useAppDispatch();
     const aircraftStatus = useAppSelector(selectAircraftStatus);
     const [takeoffAltitude, setTakeoffAltitude] = useState(0);
+    const [rtlAltitude, setRtlAltitude] = useState(0);
     const [modalState, setModalState] = useState(false);
     const [preparingTakeoff, setPreparingTakeoff] = useState(false);
+    const [preparingRtl, setPreparingRtl] = useState(false);
     const [armingInProgress, setArmingInProgress] = useState(false);
 
     return (
@@ -117,6 +119,59 @@ export default function MPSControlSection() {
                     }
                 >
                     Prepare for Takeoff
+                </Button>
+            </Box>
+            <Box
+                sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "stretch",
+                    gap: 2,
+                }}
+            >
+                <TextField
+                    size="small"
+                    required
+                    id="rtlAltitude"
+                    type="number"
+                    label="RTL Altitude (ft)"
+                    onChange={(e) => {
+                        setRtlAltitude(parseFloat(e.target.value));
+                    }}
+                    value={rtlAltitude === 0 ? "" : rtlAltitude}
+                />
+                <Button
+                    variant="contained"
+                    color={preparingRtl ? "inherit" : "warning"}
+                    disabled={preparingRtl}
+                    onClick={() => {
+                        setPreparingRtl(true);
+                        prepareRtlParams(rtlAltitude)
+                            .then((response) => {
+                                if (response.status === 200) {
+                                    dispatch(
+                                        openSnackbar({
+                                            message: "RTL parameters prepared successfully",
+                                            severity: "success",
+                                        }),
+                                    );
+                                } else {
+                                    dispatch(
+                                        openSnackbar({
+                                            message: "Failed to prepare RTL parameters",
+                                        }),
+                                    );
+                                }
+                            })
+                            .finally(() => setPreparingRtl(false));
+                    }}
+                    endIcon={
+                        <Tooltip title="Sets the RTL altitude parameter. Switch drone to RTL mode to execute">
+                            <InfoIcon fontSize="small" />
+                        </Tooltip>
+                    }
+                >
+                    Prepare RTL
                 </Button>
             </Box>
             <Box


### PR DESCRIPTION
## Summary
- Added RTL altitude input field and "Prepare RTL" button to the Drone status card
- Positioned directly below the takeoff controls for consistent layout
- Calls the `prepare_rtl_params` endpoint to set RTL_ALT parameter without triggering RTL mode

## Implementation Details
- Created `prepareRtlParams` API function in `endpoints.ts`
- Added RTL altitude state management and UI controls in `MPSControlSection.tsx`
- Button styled with warning color and includes info tooltip
- Proper loading states and snackbar notifications on success/failure

## Notes
The `prepare_rtl_params` endpoint only sets the RTL altitude parameter without changing flight mode. Users will need to manually switch to RTL mode to execute the return sequence. This differs from the `/rtl` endpoint which would immediately initiate RTL.

Generated with [Claude Code](https://claude.com/claude-code)