### PR TITLE
Simplify RTL to directly initiate return to launch

### DIFF
--- a/projects/mission-planner/src/server/httpserver.py
+++ b/projects/mission-planner/src/server/httpserver.py
@@ -282,18 +282,7 @@ class HTTP_Server:
 
         @app.route("/rtl", methods=["GET", "POST"])
         def get_post_rtl():
-            if request.method == "GET":
-                altitude = 50
-            else:
-                altitude = request.get_json().get("altitude", 50)
-
-            logger.info(f"RTL at {altitude}")
-
-            # set RTL altitude parameter
-            alt_cm = altitude * 100
-
-            if not set_parameter(self.handler, "RTL_ALT", alt_cm):
-                return "Failed to set RTL altitude parameter", 400
+            logger.info("RTL initiated")
 
             success = change_flight_mode(
                 self.handler,

--- a/projects/web-backend/src/drone/mps_api.py
+++ b/projects/web-backend/src/drone/mps_api.py
@@ -70,10 +70,8 @@ class DroneApiClient:
         return DroneApiClient._fetch_from_mission_planner("rtl")
 
     @staticmethod
-    def post_rtl(altitude):
-        return DroneApiClient._fetch_from_mission_planner(
-            "rtl", method="POST", data={"altitude": altitude}
-        )
+    def post_rtl():
+        return DroneApiClient._fetch_from_mission_planner("rtl", method="POST")
 
     @staticmethod
     def lock():

--- a/projects/web-backend/src/drone/urls.py
+++ b/projects/web-backend/src/drone/urls.py
@@ -9,7 +9,6 @@ urlpatterns = [
     path("prepare_rtl_params", views.prepare_rtl_params, name="prepare_rtl_params"),
     path("arm", views.arm, name="arm"),
     path("land", views.land, name="land"),
-    path("rtl", views.get_rtl, name="rtl"),
     path("rtl", views.post_rtl, name="rtl"),
     path("lock", views.lock, name="lock"),
     path("insert", views.insert, name="insert"),

--- a/projects/web-backend/src/drone/views.py
+++ b/projects/web-backend/src/drone/views.py
@@ -128,9 +128,7 @@ def land(request):
 @require_http_methods(["POST"])
 def post_rtl(request):
     try:
-        data = json.loads(request.body)
-        altitude = data.get("altitude")
-        response = DroneApiClient.post_rtl(altitude)
+        response = DroneApiClient.post_rtl()
         return HttpResponse(status=response.status_code)
     except (KeyError, ValueError, TypeError):
         return JsonResponse({"error": "Invalid input"}, status=400)

--- a/projects/web-backend/src/drone/views.py
+++ b/projects/web-backend/src/drone/views.py
@@ -61,10 +61,14 @@ def prepare_takeoff(request):
 
         return HttpResponse(status=response.status_code)
     except (KeyError, ValueError, TypeError) as e:
-        print(f"[ERROR] Invalid input for prepare_takeoff: {type(e).__name__}: {str(e)}")
+        print(
+            f"[ERROR] Invalid input for prepare_takeoff: {type(e).__name__}: {str(e)}"
+        )
         return JsonResponse({"error": "Invalid input"}, status=400)
     except Exception as e:
-        print(f"[ERROR] Unexpected error in prepare_takeoff: {type(e).__name__}: {str(e)}")
+        print(
+            f"[ERROR] Unexpected error in prepare_takeoff: {type(e).__name__}: {str(e)}"
+        )
         return JsonResponse(
             {"error": "Internal server error", "details": str(e)},
             status=500,
@@ -88,10 +92,14 @@ def prepare_rtl_params(request):
 
         return HttpResponse(status=response.status_code)
     except (KeyError, ValueError, TypeError) as e:
-        print(f"[ERROR] Invalid input for prepare_rtl_params: {type(e).__name__}: {str(e)}")
+        print(
+            f"[ERROR] Invalid input for prepare_rtl_params: {type(e).__name__}: {str(e)}"
+        )
         return JsonResponse({"error": "Invalid input"}, status=400)
     except Exception as e:
-        print(f"[ERROR] Unexpected error in prepare_rtl_params: {type(e).__name__}: {str(e)}")
+        print(
+            f"[ERROR] Unexpected error in prepare_rtl_params: {type(e).__name__}: {str(e)}"
+        )
         return JsonResponse(
             {"error": "Internal server error", "details": str(e)},
             status=500,
@@ -113,12 +121,6 @@ def arm(request):
 @require_http_methods(["GET"])
 def land(request):
     response = DroneApiClient.land()
-    return HttpResponse(status=response.status_code)
-
-
-@require_http_methods(["GET"])
-def get_rtl(request):
-    response = DroneApiClient.get_rtl()
     return HttpResponse(status=response.status_code)
 
 

--- a/projects/web-frontend/src/api/endpoints.ts
+++ b/projects/web-frontend/src/api/endpoints.ts
@@ -17,8 +17,8 @@ export const prepareTakeoffDrone = async (altitude: number) => {
     return await api.post("/drone/prepare_takeoff", { altitude });
 };
 
-export const prepareRtlParams = async (altitude: number) => {
-    return await api.post("/drone/prepare_rtl_params", { altitude });
+export const returnToLaunch = async (altitude: number) => {
+    return await api.post("/drone/rtl", { altitude });
 };
 
 export const postWaypointsToDrone = async (waypoints: Waypoint[]) => {

--- a/projects/web-frontend/src/api/endpoints.ts
+++ b/projects/web-frontend/src/api/endpoints.ts
@@ -17,8 +17,8 @@ export const prepareTakeoffDrone = async (altitude: number) => {
     return await api.post("/drone/prepare_takeoff", { altitude });
 };
 
-export const returnToLaunch = async (altitude: number) => {
-    return await api.post("/drone/rtl", { altitude });
+export const returnToLaunch = async () => {
+    return await api.post("/drone/rtl");
 };
 
 export const postWaypointsToDrone = async (waypoints: Waypoint[]) => {

--- a/projects/web-frontend/src/components/DroneStatus/MPSControlSection.tsx
+++ b/projects/web-frontend/src/components/DroneStatus/MPSControlSection.tsx
@@ -1,7 +1,7 @@
 import { Box, Button, Modal, Paper, TextField, Tooltip, Typography } from "@mui/material";
 import InfoIcon from "@mui/icons-material/Info";
 import { useState } from "react";
-import { armDrone, prepareTakeoffDrone, prepareRtlParams } from "../../api/endpoints.ts";
+import { armDrone, prepareTakeoffDrone, returnToLaunch } from "../../api/endpoints.ts";
 import { openSnackbar } from "../../store/slices/appSlice";
 import { selectAircraftStatus } from "../../store/slices/dataSlice";
 import { useAppDispatch, useAppSelector } from "../../store/store";
@@ -146,19 +146,19 @@ export default function MPSControlSection() {
                     disabled={preparingRtl}
                     onClick={() => {
                         setPreparingRtl(true);
-                        prepareRtlParams(rtlAltitude)
+                        returnToLaunch(rtlAltitude)
                             .then((response) => {
                                 if (response.status === 200) {
                                     dispatch(
                                         openSnackbar({
-                                            message: "RTL parameters prepared successfully",
+                                            message: "Return to launch initiated successfully",
                                             severity: "success",
                                         }),
                                     );
                                 } else {
                                     dispatch(
                                         openSnackbar({
-                                            message: "Failed to prepare RTL parameters",
+                                            message: "Failed to initiate return to launch",
                                         }),
                                     );
                                 }
@@ -171,7 +171,7 @@ export default function MPSControlSection() {
                         </Tooltip>
                     }
                 >
-                    Prepare RTL
+                    Return to Launch
                 </Button>
             </Box>
             <Box

--- a/projects/web-frontend/src/components/DroneStatus/MPSControlSection.tsx
+++ b/projects/web-frontend/src/components/DroneStatus/MPSControlSection.tsx
@@ -10,8 +10,8 @@ export default function MPSControlSection() {
     const dispatch = useAppDispatch();
     const aircraftStatus = useAppSelector(selectAircraftStatus);
     const [takeoffAltitude, setTakeoffAltitude] = useState(0);
-    const [rtlAltitude, setRtlAltitude] = useState(0);
-    const [modalState, setModalState] = useState(false);
+    const [armModalState, setArmModalState] = useState(false);
+    const [rtlModalState, setRtlModalState] = useState(false);
     const [preparingTakeoff, setPreparingTakeoff] = useState(false);
     const [preparingRtl, setPreparingRtl] = useState(false);
     const [armingInProgress, setArmingInProgress] = useState(false);
@@ -61,7 +61,7 @@ export default function MPSControlSection() {
                         variant="outlined"
                         color="error"
                         onClick={() => {
-                            setModalState(true);
+                            setArmModalState(true);
                         }}
                     >
                         Arm Drone
@@ -121,52 +121,17 @@ export default function MPSControlSection() {
                     Prepare for Takeoff
                 </Button>
             </Box>
-            <Box
-                sx={{
-                    display: "flex",
-                    justifyContent: "space-between",
-                    alignItems: "stretch",
-                    gap: 2,
-                }}
-            >
-                <TextField
-                    size="small"
-                    required
-                    id="rtlAltitude"
-                    type="number"
-                    label="RTL Altitude (ft)"
-                    onChange={(e) => {
-                        setRtlAltitude(parseFloat(e.target.value));
-                    }}
-                    value={rtlAltitude === 0 ? "" : rtlAltitude}
-                />
+            <Box>
                 <Button
+                    fullWidth
                     variant="contained"
                     color={preparingRtl ? "inherit" : "warning"}
                     disabled={preparingRtl}
                     onClick={() => {
-                        setPreparingRtl(true);
-                        returnToLaunch(rtlAltitude)
-                            .then((response) => {
-                                if (response.status === 200) {
-                                    dispatch(
-                                        openSnackbar({
-                                            message: "Return to launch initiated successfully",
-                                            severity: "success",
-                                        }),
-                                    );
-                                } else {
-                                    dispatch(
-                                        openSnackbar({
-                                            message: "Failed to initiate return to launch",
-                                        }),
-                                    );
-                                }
-                            })
-                            .finally(() => setPreparingRtl(false));
+                        setRtlModalState(true);
                     }}
                     endIcon={
-                        <Tooltip title="Sets the RTL altitude parameter. Switch drone to RTL mode to execute">
+                        <Tooltip title="Switches the drone to RTL mode using the current RTL_ALT parameter">
                             <InfoIcon fontSize="small" />
                         </Tooltip>
                     }
@@ -222,7 +187,7 @@ export default function MPSControlSection() {
                     </Box> */}
                 </Box>
             </Box>
-            <Modal open={modalState} onClose={() => setModalState(false)}>
+            <Modal open={armModalState} onClose={() => setArmModalState(false)}>
                 <Paper
                     elevation={2}
                     sx={{
@@ -241,7 +206,7 @@ export default function MPSControlSection() {
                         variant="contained"
                         color="error"
                         onClick={() => {
-                            setModalState(false);
+                            setArmModalState(false);
                             setArmingInProgress(true);
                             armDrone(true)
                                 .then((response) => {
@@ -261,6 +226,51 @@ export default function MPSControlSection() {
                                     }
                                 })
                                 .finally(() => setArmingInProgress(false));
+                        }}
+                    >
+                        Yes
+                    </Button>
+                </Paper>
+            </Modal>
+            <Modal open={rtlModalState} onClose={() => setRtlModalState(false)}>
+                <Paper
+                    elevation={2}
+                    sx={{
+                        position: "absolute",
+                        top: "50%",
+                        left: "50%",
+                        transform: "translate(-50%, -50%)",
+                        p: 4,
+                    }}
+                >
+                    <Typography variant="body1" sx={{ mb: 2, textAlign: "center" }}>
+                        Are you sure you want to return to launch?
+                    </Typography>
+                    <Button
+                        fullWidth
+                        variant="contained"
+                        color="warning"
+                        onClick={() => {
+                            setRtlModalState(false);
+                            setPreparingRtl(true);
+                            returnToLaunch()
+                                .then((response) => {
+                                    if (response.status === 200) {
+                                        dispatch(
+                                            openSnackbar({
+                                                message: "Return to launch initiated successfully",
+                                                severity: "success",
+                                            }),
+                                        );
+                                    } else {
+                                        dispatch(
+                                            openSnackbar({
+                                                message: "Failed to initiate return to launch",
+                                            }),
+                                        );
+                                    }
+                                })
+                                .finally(() => setPreparingRtl(false));
                         }}
                     >
                         Yes


### PR DESCRIPTION
## Summary
- Simplified RTL functionality to directly initiate return to launch mode without modifying altitude parameter
- Removed altitude parameter from RTL endpoint across all layers (frontend, backend, mission planner)
- Added confirmation modal for RTL action in the frontend
- Cleaned up duplicate URL patterns in Django backend

## Changes
### Mission Planner (httpserver.py)
- Removed altitude parameter handling from `/rtl` endpoint
- Removed RTL_ALT parameter setting logic
- RTL now directly initiates return to launch mode

### Web Backend
- Removed `get_rtl` view and endpoint
- Simplified `post_rtl` to not accept altitude parameter
- Fixed duplicate URL pattern for `/rtl` endpoint
- Updated `DroneApiClient.post_rtl()` to not require altitude

### Frontend
- Renamed `prepareRtlParams` to `returnToLaunch` for clarity
- Removed RTL altitude input field
- Changed "Prepare RTL" to "Return to Launch" button
- Added confirmation modal for RTL action
- Cleaned up modal state management

## Test plan
- [ ] Verify RTL button displays confirmation modal
- [ ] Confirm RTL mode is successfully initiated when confirmed
- [ ] Verify drone returns to launch using existing RTL_ALT parameter
- [ ] Test that altitude parameter is no longer sent in request