### PR TITLE
Replace MQTT capture command with WebRTC data channel

### DIFF
--- a/projects/web-backend/requirements.txt
+++ b/projects/web-backend/requirements.txt
@@ -10,4 +10,3 @@ uvicorn~=0.30.6
 asgiref~=3.8.1
 daphne~=4.2.1
 django-cors-headers~=4.9.0
-paho-mqtt~=2.1.0

--- a/projects/web-backend/src/vision/urls.py
+++ b/projects/web-backend/src/vision/urls.py
@@ -4,7 +4,6 @@ from rest_framework.routers import DefaultRouter
 from .views import (
     GroundObjectViewset,
     ImageViewset,
-    capture_image,
     deproject_pixel,
     get_odlc_session,
     patch_odlc_record,
@@ -29,5 +28,4 @@ urlpatterns = [
         name="patch_odlc_record",
     ),
     path("deproject-pixel/", deproject_pixel, name="deproject_pixel"),
-    path("capture/", capture_image, name="capture_image"),
 ]

--- a/projects/web-backend/src/vision/views.py
+++ b/projects/web-backend/src/vision/views.py
@@ -2,13 +2,9 @@ import json
 import threading
 from pathlib import Path
 
-import paho.mqtt.publish as mqtt_publish
 from django.http import HttpResponse, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
-
-MQTT_BROKER = "broker.hivemq.com"
-MQTT_TOPIC_CMD = "ubc_uas/drone_01/commands"
 from drf_spectacular.utils import extend_schema, extend_schema_view
 from rest_framework import viewsets
 
@@ -170,23 +166,6 @@ def patch_odlc_record(request, session_id: str, record_id: str):
         print(f"Error patching ODLC record: {e}")
         return JsonResponse(
             {"error": "Internal server error", "details": str(e)}, status=500
-        )
-
-
-@csrf_exempt
-@require_http_methods(["POST"])
-def capture_image(request):
-    try:
-        mqtt_publish.single(
-            MQTT_TOPIC_CMD,
-            payload=json.dumps({"action": "TAKE_PHOTO"}),
-            hostname=MQTT_BROKER,
-            port=1883,
-        )
-        return HttpResponse(status=200)
-    except Exception as e:
-        return JsonResponse(
-            {"error": "Failed to send capture command", "details": str(e)}, status=500
         )
 
 

--- a/projects/web-frontend/src/api/endpoints.ts
+++ b/projects/web-frontend/src/api/endpoints.ts
@@ -139,10 +139,6 @@ export const patchOdlcRecord = async (
  * @param depth - Depth at the pixel in meters
  * @returns A 3D point [x, y, z] in camera coordinate space, in meters
  */
-export const requestManualCapture = async (): Promise<void> => {
-    await api.post("/vision/capture/");
-};
-
 export const deprojectPixel = async (
     pixel: [number, number],
     depth: number,

--- a/projects/web-frontend/src/hooks/useWebRTCConnection.ts
+++ b/projects/web-frontend/src/hooks/useWebRTCConnection.ts
@@ -27,6 +27,7 @@ type UseWebRTCConnectionResult = {
     connect: () => void;
     disconnect: () => void;
     isConnecting: boolean;
+    sendCommand: (message: object) => void;
 };
 
 export function useWebRTCConnection(): UseWebRTCConnectionResult {
@@ -39,6 +40,7 @@ export function useWebRTCConnection(): UseWebRTCConnectionResult {
 
     const socketRef = useRef<Socket | null>(null);
     const peerConnectionRef = useRef<RTCPeerConnection | null>(null);
+    const dataChannelRef = useRef<RTCDataChannel | null>(null);
     const iceCandidateQueueRef = useRef<RTCIceCandidateInit[]>([]);
     const remotePeerIdRef = useRef<string | null>(null);
     const connectionTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -146,6 +148,7 @@ export function useWebRTCConnection(): UseWebRTCConnectionResult {
         pc.addEventListener("datachannel", (event) => {
             const channel = event.channel;
             if (channel.label === "odlc_images") {
+                dataChannelRef.current = channel;
                 channel.addEventListener("message", (msgEvent: MessageEvent<string>) => {
                     console.log("📸 ODLC Image Message Received:", msgEvent.data);
                     const parsedMessage = JSON.parse(msgEvent.data);
@@ -280,7 +283,7 @@ export function useWebRTCConnection(): UseWebRTCConnectionResult {
             clearTimeout(connectionTimeoutRef.current);
         }
 
-        const timeout_seconds = 10;
+        const timeout_seconds = 20;
         connectionTimeoutRef.current = setTimeout(() => {
             console.error(`Connection attempt timed out after ${timeout_seconds} seconds`);
             disconnect();
@@ -344,12 +347,19 @@ export function useWebRTCConnection(): UseWebRTCConnectionResult {
             peerConnectionRef.current = null;
         }
 
+        dataChannelRef.current = null;
         iceCandidateQueueRef.current = [];
         remotePeerIdRef.current = null;
         setRemoteStream(null);
         setSignalingStatus("disconnected");
         setPeerStatus("disconnected");
         setIsConnecting(false);
+    };
+
+    const sendCommand = (message: object) => {
+        if (dataChannelRef.current?.readyState === "open") {
+            dataChannelRef.current.send(JSON.stringify(message));
+        }
     };
 
     return {
@@ -359,5 +369,6 @@ export function useWebRTCConnection(): UseWebRTCConnectionResult {
         connect,
         disconnect,
         isConnecting,
+        sendCommand,
     };
 }

--- a/projects/web-frontend/src/routes/VideoFeed.tsx
+++ b/projects/web-frontend/src/routes/VideoFeed.tsx
@@ -5,10 +5,10 @@ import PhotoCamera from "@mui/icons-material/PhotoCamera";
 import VideocamIcon from "@mui/icons-material/Videocam";
 import DroneStatusCard from "../components/DroneStatusCard";
 import SessionIdDisplay from "../components/SessionIdDisplay";
-import { requestManualCapture } from "../api/endpoints";
 
 export default function VideoFeed() {
-    const { signalingStatus, peerStatus, remoteStream, connect, disconnect, isConnecting } = useWebRTCContext();
+    const { signalingStatus, peerStatus, remoteStream, connect, disconnect, isConnecting, sendCommand } =
+        useWebRTCContext();
 
     const videoRef = useRef<HTMLVideoElement>(null);
     const [capturing, setCapturing] = useState(false);
@@ -184,13 +184,10 @@ export default function VideoFeed() {
                                                 variant="outlined"
                                                 startIcon={<PhotoCamera />}
                                                 disabled={capturing || peerStatus !== "connected"}
-                                                onClick={async () => {
+                                                onClick={() => {
                                                     setCapturing(true);
-                                                    try {
-                                                        await requestManualCapture();
-                                                    } finally {
-                                                        setCapturing(false);
-                                                    }
+                                                    sendCommand({ action: "TAKE_PHOTO" });
+                                                    setCapturing(false);
                                                 }}
                                                 fullWidth
                                             >


### PR DESCRIPTION
# Description

Replaces the MQTT-based capture flow with a direct WebRTC data channel message. Previously, the capture button called `POST /vision/capture/` which published a TAKE_PHOTO command to an external MQTT broker. Now the frontend sends `{action: "TAKE_PHOTO"}` directly on the existing `odlc_images` data channel.

Changes:
- Remove `paho-mqtt` dependency from web-backend
- Remove `capture_image` view and `/vision/capture/` route
- Remove `requestManualCapture` API call from frontend
- Add `sendCommand` to `useWebRTCConnection` hook via a stored data channel ref
- Wire capture button in `VideoFeed` to send over the data channel
- Capture button is already gated on `peerStatus === "connected"` so it's disabled when no WebRTC connection is established

Resolves # (issue)

## Type of change

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

# How Has This Been Tested?

Manual testing with the WebRTC connection established and the capture button triggering a data channel message.

- [ ] Test A
- [ ] Test B

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules