### PR TITLE
fix: restore prepare/reducer split so odlcSyncMiddleware can POST new…

### DIFF
--- a/projects/web-frontend/src/hooks/useWebRTCConnection.ts
+++ b/projects/web-frontend/src/hooks/useWebRTCConnection.ts
@@ -3,7 +3,7 @@ import { io, Socket } from "socket.io-client";
 import { SIGNALING_SERVER_URL } from "../constants";
 import { OdlcImageSchema } from "../schemas/odlc";
 import { useAppDispatch } from "../store/store";
-import { appendOdlcImage } from "../store/slices/dataSlice";
+import { appendOdlcImageFromAircraft } from "../store/thunks/odlcSessionThunks";
 
 export type DepthResult = {
     u: number;
@@ -177,7 +177,7 @@ export function useWebRTCConnection(): UseWebRTCConnectionResult {
                         console.error("Invalid ODLC image data received:", result.error);
                         return;
                     }
-                    dispatch(appendOdlcImage(result.data));
+                    dispatch(appendOdlcImageFromAircraft(result.data));
                 });
             }
         });

--- a/projects/web-frontend/src/routes/OdlcImages.tsx
+++ b/projects/web-frontend/src/routes/OdlcImages.tsx
@@ -34,11 +34,10 @@ import {
     undoLastOdlcImageAnnotation,
     deleteOdlcImageAnnotation,
     setOdlcImageAnnotationMeasurements,
-    appendOdlcImage,
 } from "../store/slices/dataSlice";
 import ImageAnnotationOverlay from "../components/ImageAnnotationOverlay";
 import SessionIdDisplay from "../components/SessionIdDisplay";
-import { syncOdlcImageToBackend } from "../store/thunks/odlcSessionThunks";
+import { syncOdlcImageToBackend, appendOdlcImageFromAircraft } from "../store/thunks/odlcSessionThunks";
 import type { OdlcImageRecord } from "../store/slices/dataSlice";
 import { classifyOdlcColor, ODLC_COLORS, ODLC_COLOR_LABELS } from "../utils/odlcColorGroup";
 import type { OdlcColor, RGB } from "../utils/odlcColorGroup";
@@ -248,7 +247,7 @@ export default function OdlcImages() {
             createDummyOdlcImage([0, 180, 0], 60),
             createDummyOdlcImage([0, 180, 0], 55),
         ];
-        samples.forEach((img) => dispatch(appendOdlcImage(img)));
+        samples.forEach((img) => dispatch(appendOdlcImageFromAircraft(img)));
     }, [dispatch]);
 
     const handleImageAnnotation = async (args: {

--- a/projects/web-frontend/src/store/slices/dataSlice.ts
+++ b/projects/web-frontend/src/store/slices/dataSlice.ts
@@ -139,16 +139,21 @@ const dataSlice = createSlice({
         setTakeoffWaypoint: (state, action: PayloadAction<Waypoint | null>) => {
             state.takeoffWaypoint = action.payload;
         },
-        appendOdlcImage: (state, action: PayloadAction<OdlcImage>) => {
-            state.odlcImageRecords.push({
-                id: crypto.randomUUID(),
-                receivedAt: Date.now(),
-                image: action.payload,
-                flagged: false,
-                textInput: "",
-                metadata: `Direction: ${Math.round(state.aircraftStatus.heading)}°`,
-                annotations: [],
-            });
+        appendOdlcImage: {
+            reducer: (state, action: PayloadAction<OdlcImageRecord>) => {
+                state.odlcImageRecords.push(action.payload);
+            },
+            prepare: (image: OdlcImage, heading: number) => ({
+                payload: {
+                    id: crypto.randomUUID(),
+                    receivedAt: Date.now(),
+                    image,
+                    flagged: false,
+                    textInput: "",
+                    metadata: `Direction: ${Math.round(heading)}°`,
+                    annotations: [],
+                } as OdlcImageRecord,
+            }),
         },
         loadOdlcImageRecords: (state, action: PayloadAction<OdlcImageRecord[]>) => {
             state.odlcImageRecords = action.payload;

--- a/projects/web-frontend/src/store/thunks/odlcSessionThunks.ts
+++ b/projects/web-frontend/src/store/thunks/odlcSessionThunks.ts
@@ -1,8 +1,16 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
 import { getOdlcSession, patchOdlcRecord } from "../../api/endpoints";
-import { clearOdlcImages, loadOdlcImageRecords } from "../slices/dataSlice";
+import { appendOdlcImage, clearOdlcImages, loadOdlcImageRecords } from "../slices/dataSlice";
 import { setOdlcSessionId } from "../slices/appSlice";
-import { RootState } from "../store";
+import { AppDispatch, RootState } from "../store";
+import type { OdlcImage } from "../../schemas/odlc";
+
+export const appendOdlcImageFromAircraft =
+    (image: OdlcImage) =>
+    (dispatch: AppDispatch, getState: () => RootState) => {
+        const heading = getState().data.aircraftStatus.heading;
+        dispatch(appendOdlcImage(image, heading));
+    };
 
 export const syncOdlcImageToBackend = createAsyncThunk<void, string, { state: RootState }>(
     "odlcSession/syncImage",


### PR DESCRIPTION
… records

The plain-reducer form of appendOdlcImage put OdlcImage (not OdlcImageRecord) in action.payload, so the middleware's payload.id guard was always undefined and the POST to save new records was silently skipped.

Restore the prepare/reducer split so action.payload is always a full OdlcImageRecord. Introduce appendOdlcImageFromAircraft thunk to read the live heading from store state at dispatch time, avoiding the stale-closure issue that would arise from capturing heading via useAppSelector inside the WebRTC data channel callback.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Resolves # (issue)

## Type of change

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Test A
- [ ] Test B

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
