### PR TITLE
feat: include per-image heading in S3 sidecar JSON

### DIFF
--- a/projects/web-backend/src/vision/storage.py
+++ b/projects/web-backend/src/vision/storage.py
@@ -118,6 +118,7 @@ _METADATA_FIELDS = (
     "confidenceLevel",
     "yawDeg",
     "colorDetection",
+    "heading",
 )
 
 def loadSideCarDict(sidecar_key: str) -> dict[str, Any]:

--- a/projects/web-backend/src/vision/views.py
+++ b/projects/web-backend/src/vision/views.py
@@ -141,6 +141,7 @@ def post_odlc_record(request, session_id: str):
                         "confidenceLevel": image.get("confidence_level"),
                         "yawDeg": image.get("yaw_deg"),
                         "colorDetection": image.get("color_detection"),
+                        "heading": record.get("metadata"),
                     },
                 )
             except Exception as e:

--- a/projects/web-frontend/src/components/Nav.tsx
+++ b/projects/web-frontend/src/components/Nav.tsx
@@ -28,7 +28,7 @@ export default function Nav() {
     });
 
     useEffect(() => {
-        setTab(params?.route === undefined ? 0 : (linkMap[params.route] ?? false));
+        setTab(params?.route === undefined ? 0 : linkMap[params.route] ?? false);
     }, [params?.route]);
 
     const handleNav = (_event: React.SyntheticEvent, newValue: number) => {

--- a/projects/web-frontend/src/routes/DepthArchive.tsx
+++ b/projects/web-frontend/src/routes/DepthArchive.tsx
@@ -31,6 +31,7 @@ const DEFAULT_BOUNDING_BOX: Array<[number, number]> = [
     [0, 0],
     [1, 1],
 ];
+const ARCHIVE_POLL_INTERVAL_MS = 1000;
 
 /**
  * Backend endpoints consumed here:
@@ -173,6 +174,8 @@ export default function DepthArchive() {
     const [records, setRecords] = useState<OdlcImageRecord[]>([]);
     const [selectedRecordId, setSelectedRecordId] = useState<string | null>(null);
     const [highlightedAnnotationId, setHighlightedAnnotationId] = useState<string | null>(null);
+    const [isPolling, setIsPolling] = useState(false);
+    const [lastPolledAt, setLastPolledAt] = useState<Date | null>(null);
 
     const recordsCacheRef = useRef(new Map<string, OdlcImageRecord[]>());
     const selectedDateRef = useRef(selectedDate);
@@ -191,15 +194,18 @@ export default function DepthArchive() {
         [records, selectedRecordId],
     );
 
-    const applyRecordsUpdate = useCallback((date: string, updater: (current: OdlcImageRecord[]) => OdlcImageRecord[]) => {
-        const current = recordsCacheRef.current.get(date) ?? [];
-        const next = updater(current);
-        recordsCacheRef.current.set(date, next);
+    const applyRecordsUpdate = useCallback(
+        (date: string, updater: (current: OdlcImageRecord[]) => OdlcImageRecord[]) => {
+            const current = recordsCacheRef.current.get(date) ?? [];
+            const next = updater(current);
+            recordsCacheRef.current.set(date, next);
 
-        if (selectedDateRef.current === date) {
-            setRecords(next);
-        }
-    }, []);
+            if (selectedDateRef.current === date) {
+                setRecords(next);
+            }
+        },
+        [],
+    );
 
     const loadDates = useCallback(async () => {
         setDatesLoading(true);
@@ -211,9 +217,7 @@ export default function DepthArchive() {
             recordsCacheRef.current.clear();
             setAvailableDates(parsedDates);
             setDatesLoaded(true);
-            setSelectedDate((current) =>
-                current && parsedDates.includes(current) ? current : (parsedDates[0] ?? ""),
-            );
+            setSelectedDate((current) => (current && parsedDates.includes(current) ? current : parsedDates[0] ?? ""));
         } catch (error) {
             setAvailableDates([]);
             setDatesLoaded(false);
@@ -232,6 +236,66 @@ export default function DepthArchive() {
 
     useEffect(() => {
         let cancelled = false;
+        let pollInFlight = false;
+        let pollInterval: ReturnType<typeof setInterval> | null = null;
+
+        function cleanup() {
+            cancelled = true;
+            if (pollInterval !== null) {
+                clearInterval(pollInterval);
+            }
+            setIsPolling(false);
+            setLastPolledAt(null);
+        }
+
+        function startPolling() {
+            pollInterval = setInterval(() => {
+                if (cancelled || pollInFlight) {
+                    return;
+                }
+                pollInFlight = true;
+                setIsPolling(true);
+
+                void (async () => {
+                    try {
+                        const date = selectedDate;
+                        const entries = ArchiveRecordsSchema.parse(await getArchiveRecordsForDate(date));
+                        if (cancelled) {
+                            return;
+                        }
+
+                        const existingIds = new Set((recordsCacheRef.current.get(date) ?? []).map((r) => r.id));
+                        const newEntries = entries.filter((entry) => !existingIds.has(`${date}:${entry.id}`));
+
+                        if (newEntries.length > 0) {
+                            const settled = await Promise.allSettled(
+                                newEntries.map((entry) => loadArchiveRecord(date, entry)),
+                            );
+                            if (cancelled) {
+                                return;
+                            }
+
+                            const loadedRecords = settled
+                                .filter((r): r is PromiseFulfilledResult<OdlcImageRecord> => r.status === "fulfilled")
+                                .map((r) => r.value);
+
+                            if (loadedRecords.length > 0) {
+                                applyRecordsUpdate(date, (current) => [...current, ...loadedRecords]);
+                            }
+                        }
+
+                        setLastPolledAt(new Date());
+                    } catch {
+                        // silently skip — don't disrupt the existing view on transient failures
+                    } finally {
+                        pollInFlight = false;
+                        if (!cancelled) {
+                            setIsPolling(false);
+                        }
+                    }
+                })();
+            }, ARCHIVE_POLL_INTERVAL_MS);
+        }
 
         if (selectedDate.length === 0) {
             setRecords([]);
@@ -244,7 +308,8 @@ export default function DepthArchive() {
             setRecords(recordsCacheRef.current.get(selectedDate) ?? []);
             setRecordsError(null);
             setRecordsLoading(false);
-            return undefined;
+            startPolling();
+            return cleanup;
         }
 
         setRecords([]);
@@ -262,6 +327,7 @@ export default function DepthArchive() {
                 recordsCacheRef.current.set(selectedDate, []);
                 setRecords([]);
                 setRecordsLoading(false);
+                startPolling();
                 return;
             }
 
@@ -288,6 +354,8 @@ export default function DepthArchive() {
                         : `Failed to load archive images for ${selectedDate}`;
                 setRecordsError(formatArchiveError(prefix, failedResults[0].reason));
             }
+
+            startPolling();
         })().catch((error) => {
             if (cancelled) {
                 return;
@@ -299,10 +367,8 @@ export default function DepthArchive() {
             setRecordsError(formatArchiveError(`Failed to load archive images for ${selectedDate}`, error));
         });
 
-        return () => {
-            cancelled = true;
-        };
-    }, [selectedDate]);
+        return cleanup;
+    }, [selectedDate, applyRecordsUpdate]);
 
     useEffect(() => {
         if (records.length === 0) {
@@ -351,7 +417,12 @@ export default function DepthArchive() {
     }, [selectedRecord]);
 
     const handleImageAnnotation = useCallback(
-        async (args: { id: string; annotationId: string; p1: { x: number; y: number }; p2: { x: number; y: number } }) => {
+        async (args: {
+            id: string;
+            annotationId: string;
+            p1: { x: number; y: number };
+            p2: { x: number; y: number };
+        }) => {
             const date = selectedDateRef.current;
             if (!date) {
                 return;
@@ -362,10 +433,7 @@ export default function DepthArchive() {
                     record.id === args.id
                         ? {
                               ...record,
-                              annotations: [
-                                  ...record.annotations,
-                                  { id: args.annotationId, p1: args.p1, p2: args.p2 },
-                              ],
+                              annotations: [...record.annotations, { id: args.annotationId, p1: args.p1, p2: args.p2 }],
                           }
                         : record,
                 ),
@@ -427,7 +495,9 @@ export default function DepthArchive() {
                     record.id === args.id
                         ? {
                               ...record,
-                              annotations: record.annotations.filter((annotation) => annotation.id !== args.annotationId),
+                              annotations: record.annotations.filter(
+                                  (annotation) => annotation.id !== args.annotationId,
+                              ),
                           }
                         : record,
                 ),
@@ -504,9 +574,23 @@ export default function DepthArchive() {
                     <Typography variant="subtitle2" color="text.secondary" gutterBottom>
                         Archive Images
                     </Typography>
-                    <Typography variant="caption" color="text.secondary" sx={{ mb: 1.5 }}>
-                        {selectedDate ? `${records.length} loaded for ${selectedDate}` : "Select a date to load images"}
-                    </Typography>
+                    <Box sx={{ mb: 1.5 }}>
+                        <Typography variant="caption" color="text.secondary" display="block">
+                            {selectedDate
+                                ? `${records.length} loaded for ${selectedDate}`
+                                : "Select a date to load images"}
+                        </Typography>
+                        {selectedDate && !recordsLoading && (isPolling || lastPolledAt !== null) && (
+                            <Stack direction="row" alignItems="center" spacing={0.5} sx={{ mt: 0.5 }}>
+                                {isPolling && <CircularProgress size={10} />}
+                                <Typography variant="caption" color="text.secondary">
+                                    {isPolling
+                                        ? "Checking for new images..."
+                                        : `Updated ${lastPolledAt!.toLocaleTimeString()}`}
+                                </Typography>
+                            </Stack>
+                        )}
+                    </Box>
 
                     <Box sx={{ flex: 1, minHeight: 0, overflowY: "auto" }}>
                         {recordsLoading ? (
@@ -530,7 +614,8 @@ export default function DepthArchive() {
                                             borderRadius: 1,
                                             cursor: "pointer",
                                             border: "1px solid",
-                                            borderColor: selectedRecordId === record.id ? "primary.main" : "transparent",
+                                            borderColor:
+                                                selectedRecordId === record.id ? "primary.main" : "transparent",
                                             bgcolor: selectedRecordId === record.id ? "action.selected" : "transparent",
                                             "&:hover": { bgcolor: "action.hover" },
                                         }}
@@ -567,7 +652,8 @@ export default function DepthArchive() {
 
                 <Paper sx={{ flex: 1, p: 2, display: "flex", flexDirection: "column", minWidth: 0 }}>
                     <Typography variant="caption" color="text.secondary" sx={{ mb: 1 }}>
-                        Click &amp; hold to draw a line between 2 points · Ctrl+Z to undo · Double-click a line to delete
+                        Click &amp; hold to draw a line between 2 points · Ctrl+Z to undo · Double-click a line to
+                        delete
                     </Typography>
 
                     <Box

--- a/projects/web-frontend/src/routes/DepthArchive.tsx
+++ b/projects/web-frontend/src/routes/DepthArchive.tsx
@@ -3,6 +3,7 @@ import {
     Box,
     Button,
     CircularProgress,
+    IconButton,
     MenuItem,
     Paper,
     Stack,
@@ -15,6 +16,8 @@ import {
     TextField,
     Typography,
 } from "@mui/material";
+import ChevronLeft from "@mui/icons-material/ChevronLeft";
+import ChevronRight from "@mui/icons-material/ChevronRight";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { z } from "zod";
 import ImageAnnotationOverlay from "../components/ImageAnnotationOverlay";
@@ -177,6 +180,26 @@ export default function DepthArchive() {
     const [isPolling, setIsPolling] = useState(false);
     const [lastPolledAt, setLastPolledAt] = useState<Date | null>(null);
 
+    // Thumbnail row: 40px img + 0.75*2 padding (12) + 1px border*2 + 0.25*8 spacing gap
+    const ROW_HEIGHT_PX = 56;
+    const [pageSize, setPageSize] = useState(1);
+    const [page, setPage] = useState(0);
+
+    const resizeObserverRef = useRef<ResizeObserver | null>(null);
+    const listContainerCallbackRef = useCallback((el: HTMLDivElement | null) => {
+        resizeObserverRef.current?.disconnect();
+        resizeObserverRef.current = null;
+        if (!el) return;
+        const recompute = () => {
+            const next = Math.max(1, Math.floor(el.clientHeight / ROW_HEIGHT_PX));
+            setPageSize((prev) => (prev === next ? prev : next));
+        };
+        recompute();
+        const ro = new ResizeObserver(recompute);
+        ro.observe(el);
+        resizeObserverRef.current = ro;
+    }, []);
+
     const recordsCacheRef = useRef(new Map<string, OdlcImageRecord[]>());
     const selectedDateRef = useRef(selectedDate);
     const recordsRef = useRef(records);
@@ -188,6 +211,18 @@ export default function DepthArchive() {
     useEffect(() => {
         recordsRef.current = records;
     }, [records]);
+
+    const totalPages = Math.max(1, Math.ceil(records.length / pageSize));
+    const clampedPage = Math.min(page, totalPages - 1);
+    const paginatedRecords = useMemo(
+        () => records.slice(clampedPage * pageSize, (clampedPage + 1) * pageSize),
+        [records, clampedPage, pageSize],
+    );
+
+    // Reset to first page when the record list or page size changes
+    useEffect(() => {
+        setPage(0);
+    }, [records, pageSize]);
 
     const selectedRecord = useMemo(
         () => records.find((record) => record.id === selectedRecordId) ?? null,
@@ -280,7 +315,7 @@ export default function DepthArchive() {
                                 .map((r) => r.value);
 
                             if (loadedRecords.length > 0) {
-                                applyRecordsUpdate(date, (current) => [...current, ...loadedRecords]);
+                                applyRecordsUpdate(date, (current) => [...loadedRecords, ...current]);
                             }
                         }
 
@@ -592,7 +627,7 @@ export default function DepthArchive() {
                         )}
                     </Box>
 
-                    <Box sx={{ flex: 1, minHeight: 0, overflowY: "auto" }}>
+                    <Box ref={listContainerCallbackRef} sx={{ flex: 1, minHeight: 0, overflow: "hidden" }}>
                         {recordsLoading ? (
                             <Stack spacing={1} alignItems="center" justifyContent="center" sx={{ minHeight: 160 }}>
                                 <CircularProgress size={24} />
@@ -602,7 +637,7 @@ export default function DepthArchive() {
                             </Stack>
                         ) : records.length > 0 ? (
                             <Stack spacing={0.25}>
-                                {records.map((record) => (
+                                {paginatedRecords.map((record) => (
                                     <Box
                                         key={record.id}
                                         onClick={() => setSelectedRecordId(record.id)}
@@ -648,6 +683,40 @@ export default function DepthArchive() {
                             </Stack>
                         )}
                     </Box>
+
+                    {records.length > pageSize && (
+                        <Box
+                            sx={{
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "space-between",
+                                mt: 2,
+                                pt: 1,
+                                borderTop: 1,
+                                borderColor: "divider",
+                            }}
+                        >
+                            <IconButton
+                                size="small"
+                                disabled={clampedPage === 0}
+                                onClick={() => setPage((p) => Math.max(0, p - 1))}
+                                aria-label="Previous page"
+                            >
+                                <ChevronLeft />
+                            </IconButton>
+                            <Typography variant="caption" color="text.secondary">
+                                {clampedPage + 1} / {totalPages}
+                            </Typography>
+                            <IconButton
+                                size="small"
+                                disabled={clampedPage >= totalPages - 1}
+                                onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                                aria-label="Next page"
+                            >
+                                <ChevronRight />
+                            </IconButton>
+                        </Box>
+                    )}
                 </Paper>
 
                 <Paper sx={{ flex: 1, p: 2, display: "flex", flexDirection: "column", minWidth: 0 }}>

--- a/projects/web-frontend/src/routes/DepthArchive.tsx
+++ b/projects/web-frontend/src/routes/DepthArchive.tsx
@@ -52,6 +52,7 @@ const ArchiveRecordSchema = z.object({
     confidenceLevel: z.number().optional(),
     yawDeg: z.number().nullable().optional(),
     colorDetection: z.tuple([z.number().int(), z.number().int(), z.number().int()]).optional(),
+    heading: z.string().nullable().optional(),
 });
 
 const ArchiveRecordsSchema = z.array(ArchiveRecordSchema);
@@ -86,13 +87,34 @@ function getRecordTimestamp(receivedAt: string | number | undefined): number {
     return Date.now();
 }
 
-function buildArchiveMetadata(date: string, entryId: string, colorKey: string, depthKey: string | null): string {
-    return [
-        `Archive date: ${date}`,
-        `Archive entry: ${entryId}`,
-        `Color key: ${colorKey}`,
-        `Depth key: ${depthKey ?? "None"}`,
-    ].join("\n");
+function formatArchiveMetadata(record: OdlcImageRecord): string {
+    const { image, receivedAt } = record;
+    const [r, g, b] = image.color_detection;
+    const colorName = ODLC_COLOR_LABELS[classifyOdlcColor(image.color_detection as RGB)];
+    const directionLine =
+        image.yaw_deg != null
+            ? `Direction: ${image.yaw_deg.toFixed(1)}° ${yawToCompass(image.yaw_deg)}`
+            : "Direction: N/A";
+
+    // Derive archive date / entry id from the composite record id ("date:uuid").
+    const colonIdx = record.id.indexOf(":");
+    const archiveDate = colonIdx >= 0 ? record.id.slice(0, colonIdx) : "";
+    const archiveEntry = colonIdx >= 0 ? record.id.slice(colonIdx + 1) : record.id;
+
+    const lines = [
+        `Received: ${new Date(receivedAt).toISOString()}`,
+        `Confidence: ${image.confidence_level}`,
+        `Color: ${colorName} (RGB: ${r}, ${g}, ${b})`,
+        directionLine,
+        `Bounding box: ${image.bounding_box.map(([x, y]) => `(${x.toFixed(2)}, ${y.toFixed(2)})`).join(", ")}`,
+        ...(archiveDate ? [`Archive date: ${archiveDate}`, `Archive entry: ${archiveEntry}`] : []),
+    ];
+
+    if (record.metadata.trim().length > 0) {
+        lines.push("", record.metadata.trim());
+    }
+
+    return lines.join("\n");
 }
 
 function createArchiveImage(entry: ArchiveRecord, colorBase64: string, depthBase64: string | null): OdlcImage {
@@ -106,28 +128,6 @@ function createArchiveImage(entry: ArchiveRecord, colorBase64: string, depthBase
     };
 }
 
-function formatArchiveMetadata(record: OdlcImageRecord): string {
-    const { image, receivedAt } = record;
-    const [r, g, b] = image.color_detection;
-    const colorName = ODLC_COLOR_LABELS[classifyOdlcColor(image.color_detection as RGB)];
-    const directionLine =
-        image.yaw_deg != null
-            ? `Direction: ${image.yaw_deg.toFixed(1)}° ${yawToCompass(image.yaw_deg)}`
-            : "Direction: N/A";
-    const lines = [
-        `Received: ${new Date(receivedAt).toISOString()}`,
-        `Confidence: ${image.confidence_level}`,
-        `Color: ${colorName} (RGB: ${r}, ${g}, ${b})`,
-        directionLine,
-        `Bounding box: ${image.bounding_box.map(([x, y]) => `(${x.toFixed(2)}, ${y.toFixed(2)})`).join(", ")}`,
-    ];
-
-    if (record.metadata.trim().length > 0) {
-        lines.push("", record.metadata.trim());
-    }
-
-    return lines.join("\n");
-}
 
 function getArchiveItemLabel(record: OdlcImageRecord): string {
     const entryId = record.id.split(":").slice(1).join(":") || record.id;
@@ -158,7 +158,7 @@ async function loadArchiveRecord(date: string, entry: ArchiveRecord): Promise<Od
         image: createArchiveImage(entry, imageData, depthData),
         flagged: false,
         textInput: "",
-        metadata: buildArchiveMetadata(date, entry.id, colorKey, depthKey),
+        metadata: entry.heading ?? "",
         annotations: [],
     };
 }
@@ -682,7 +682,7 @@ export default function DepthArchive() {
                                     onUndo={handleUndo}
                                     onDeleteAnnotation={handleDeleteAnnotation}
                                 />
-                                {selectedRecord.image.yaw_deg != null && (
+                                {(selectedRecord.metadata.trim() || selectedRecord.image.yaw_deg != null) && (
                                     <Box
                                         sx={{
                                             position: "absolute",
@@ -699,20 +699,22 @@ export default function DepthArchive() {
                                             pointerEvents: "none",
                                         }}
                                     >
-                                        <Box
-                                            component="span"
-                                            sx={{
-                                                display: "inline-block",
-                                                transform: `rotate(${selectedRecord.image.yaw_deg}deg)`,
-                                                fontSize: "1rem",
-                                                lineHeight: 1,
-                                            }}
-                                        >
-                                            ↑
-                                        </Box>
+                                        {selectedRecord.image.yaw_deg != null && (
+                                            <Box
+                                                component="span"
+                                                sx={{
+                                                    display: "inline-block",
+                                                    transform: `rotate(${selectedRecord.image.yaw_deg}deg)`,
+                                                    fontSize: "1rem",
+                                                    lineHeight: 1,
+                                                }}
+                                            >
+                                                ↑
+                                            </Box>
+                                        )}
                                         <Typography variant="caption" sx={{ color: "#fff", fontFamily: "monospace" }}>
-                                            {selectedRecord.image.yaw_deg.toFixed(1)}°{" "}
-                                            {yawToCompass(selectedRecord.image.yaw_deg)}
+                                            {selectedRecord.metadata.trim() ||
+                                                `${selectedRecord.image.yaw_deg!.toFixed(1)}° ${yawToCompass(selectedRecord.image.yaw_deg!)}`}
                                         </Typography>
                                     </Box>
                                 )}

--- a/projects/web-frontend/src/routes/OdlcImages.tsx
+++ b/projects/web-frontend/src/routes/OdlcImages.tsx
@@ -123,8 +123,8 @@ function formatImageMetadata(record: OdlcImageRecord): string {
     const directionLine = metadata.trim()
         ? metadata.trim()
         : image.yaw_deg != null
-          ? `Direction: ${image.yaw_deg.toFixed(1)}°`
-          : `Direction: N/A`;
+        ? `Direction: ${image.yaw_deg.toFixed(1)}°`
+        : `Direction: N/A`;
     const lines = [
         `Received: ${new Date(receivedAt).toISOString()}`,
         `Confidence: ${image.confidence_level}`,

--- a/projects/web-frontend/src/routes/VideoFeed.tsx
+++ b/projects/web-frontend/src/routes/VideoFeed.tsx
@@ -11,8 +11,16 @@ import SessionIdDisplay from "../components/SessionIdDisplay";
 type DepthSampleMarker = { x: number; y: number };
 
 export default function VideoFeed() {
-    const { signalingStatus, peerStatus, remoteStream, connect, disconnect, isConnecting, sendCommand, lastDepthResult } =
-        useWebRTCContext();
+    const {
+        signalingStatus,
+        peerStatus,
+        remoteStream,
+        connect,
+        disconnect,
+        isConnecting,
+        sendCommand,
+        lastDepthResult,
+    } = useWebRTCContext();
 
     const videoRef = useRef<HTMLVideoElement>(null);
     const [capturing, setCapturing] = useState(false);
@@ -289,15 +297,41 @@ export default function VideoFeed() {
                                                         rowGap: 0.5,
                                                     }}
                                                 >
-                                                    <Typography variant="caption" color="text.secondary" fontFamily="monospace">u</Typography>
-                                                    <Typography variant="caption" fontFamily="monospace">{lastDepthResult.u.toFixed(4)}</Typography>
-                                                    <Typography variant="caption" color="text.secondary" fontFamily="monospace">v</Typography>
-                                                    <Typography variant="caption" fontFamily="monospace">{lastDepthResult.v.toFixed(4)}</Typography>
-                                                    <Typography variant="caption" color="text.secondary" fontFamily="monospace">depth</Typography>
+                                                    <Typography
+                                                        variant="caption"
+                                                        color="text.secondary"
+                                                        fontFamily="monospace"
+                                                    >
+                                                        u
+                                                    </Typography>
+                                                    <Typography variant="caption" fontFamily="monospace">
+                                                        {lastDepthResult.u.toFixed(4)}
+                                                    </Typography>
+                                                    <Typography
+                                                        variant="caption"
+                                                        color="text.secondary"
+                                                        fontFamily="monospace"
+                                                    >
+                                                        v
+                                                    </Typography>
+                                                    <Typography variant="caption" fontFamily="monospace">
+                                                        {lastDepthResult.v.toFixed(4)}
+                                                    </Typography>
+                                                    <Typography
+                                                        variant="caption"
+                                                        color="text.secondary"
+                                                        fontFamily="monospace"
+                                                    >
+                                                        depth
+                                                    </Typography>
                                                     <Typography
                                                         variant="caption"
                                                         fontFamily="monospace"
-                                                        color={lastDepthResult.depth_m === null ? "text.secondary" : "text.primary"}
+                                                        color={
+                                                            lastDepthResult.depth_m === null
+                                                                ? "text.secondary"
+                                                                : "text.primary"
+                                                        }
                                                     >
                                                         {lastDepthResult.depth_m === null
                                                             ? "N/A"

--- a/projects/web-frontend/src/store/slices/dataSlice.ts
+++ b/projects/web-frontend/src/store/slices/dataSlice.ts
@@ -5,7 +5,6 @@ import { RootState } from "../store";
 import { Waypoint } from "../../types/Waypoint";
 import type { OdlcImage } from "../../schemas/odlc";
 
-
 // Per-image annotation: line segment with optional backend-computed distance
 // and deprojected camera-frame endpoints (meters). The 3D points are populated
 // asynchronously alongside `distance` and used to render dX/dY/dZ in meters.

--- a/projects/web-frontend/src/store/thunks/odlcSessionThunks.ts
+++ b/projects/web-frontend/src/store/thunks/odlcSessionThunks.ts
@@ -5,12 +5,10 @@ import { setOdlcSessionId } from "../slices/appSlice";
 import { AppDispatch, RootState } from "../store";
 import type { OdlcImage } from "../../schemas/odlc";
 
-export const appendOdlcImageFromAircraft =
-    (image: OdlcImage) =>
-    (dispatch: AppDispatch, getState: () => RootState) => {
-        const heading = getState().data.aircraftStatus.heading;
-        dispatch(appendOdlcImage(image, heading));
-    };
+export const appendOdlcImageFromAircraft = (image: OdlcImage) => (dispatch: AppDispatch, getState: () => RootState) => {
+    const heading = getState().data.aircraftStatus.heading;
+    dispatch(appendOdlcImage(image, heading));
+};
 
 export const syncOdlcImageToBackend = createAsyncThunk<void, string, { state: RootState }>(
     "odlcSession/syncImage",

--- a/projects/web-frontend/src/utils/odlcImageAnnotationUtils.ts
+++ b/projects/web-frontend/src/utils/odlcImageAnnotationUtils.ts
@@ -125,9 +125,7 @@ export const calculateAnnotationDistance = async (
         const p1_3d: CameraPoint3D = [res1.point[0], res1.point[1], res1.point[2]];
         const p2_3d: CameraPoint3D = [res2.point[0], res2.point[1], res2.point[2]];
 
-        const dist = Math.sqrt(
-            (p2_3d[0] - p1_3d[0]) ** 2 + (p2_3d[1] - p1_3d[1]) ** 2 + (p2_3d[2] - p1_3d[2]) ** 2,
-        );
+        const dist = Math.sqrt((p2_3d[0] - p1_3d[0]) ** 2 + (p2_3d[1] - p1_3d[1]) ** 2 + (p2_3d[2] - p1_3d[2]) ** 2);
         console.log("Calculated distance (m):", dist);
         return { distance: dist, p1_3d, p2_3d };
     } catch (error) {


### PR DESCRIPTION
Add the aircraft heading (stored as record.metadata, e.g. "Direction: 90°") to the per-image sidecar JSON uploaded to S3 alongside each ODLC capture.

The heading is captured from aircraftStatus.heading on the frontend at the moment the image is received, making it subtly distinct from yawDeg which comes from the drone's onboard sensor embedded in the image payload.

Also adds "heading" to the _METADATA_FIELDS reference tuple in storage.py.

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Resolves # (issue)

## Type of change

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [ ] Test A
- [ ] Test B

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code._

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
